### PR TITLE
feat(orchestrator): allow timeout in run-matrix (#18)

### DIFF
--- a/src/vllm_cibench/orchestrators/run_matrix.py
+++ b/src/vllm_cibench/orchestrators/run_matrix.py
@@ -26,13 +26,14 @@ def scenarios_from_matrix(matrix: Dict[str, object]) -> Iterable[str]:
 
 
 def execute_matrix(
-    run_type: str = "pr", *, root: Optional[str] = None
+    run_type: str = "pr", *, root: Optional[str] = None, timeout_s: float = 60.0
 ) -> Dict[str, object]:
     """执行 matrix 中的所有场景，返回结果映射。
 
     参数:
         run_type: 运行类型（pr/daily）。
         root: 仓库根路径，默认 CWD。
+        timeout_s: 探活最大等待时长（秒），会传递给单场景执行函数。
 
     返回值:
         dict: {scenario_id: result_dict}
@@ -46,6 +47,6 @@ def execute_matrix(
     results: Dict[str, object] = {}
     for sid in scenarios_from_matrix(matrix):
         results[sid] = run_pipeline.execute(
-            scenario_id=sid, run_type=run_type, root=str(base)
+            scenario_id=sid, run_type=run_type, root=str(base), timeout_s=timeout_s
         )
     return results

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -143,8 +143,11 @@ def run_matrix(
     root: Optional[str] = typer.Option(
         None, "--root", help="项目根目录（默认当前工作目录）"
     ),
+    timeout: float = typer.Option(60.0, "--timeout", help="探活最大等待时长（秒）"),
 ) -> None:
     """批量执行 matrix.yaml 中的所有场景。"""
 
-    res = run_matrix_mod.execute_matrix(run_type=run_type, root=root)
+    res = run_matrix_mod.execute_matrix(
+        run_type=run_type, root=root, timeout_s=timeout
+    )
     typer.echo(json.dumps(res, ensure_ascii=False))

--- a/tests/orchestrators/test_run_matrix.py
+++ b/tests/orchestrators/test_run_matrix.py
@@ -8,18 +8,19 @@ import vllm_cibench.orchestrators.run_matrix as rm
 
 
 def test_execute_matrix_calls_pipeline(monkeypatch):
-    """应按 matrix 中的所有场景调用 run_pipeline.execute。"""
+    """应按 matrix 中的所有场景调用 run_pipeline.execute 并传递超时时长。"""
 
     called = []
 
     def fake_execute(
         *, scenario_id: str, run_type: str, root: str, timeout_s: float = 60.0
     ):
-        called.append((scenario_id, run_type))
+        called.append((scenario_id, run_type, timeout_s))
         return {"scenario": scenario_id, "ok": True}
 
     monkeypatch.setattr(rm.run_pipeline, "execute", fake_execute)
-    out = rm.execute_matrix(run_type="pr", root=str(Path.cwd()))
+    out = rm.execute_matrix(run_type="pr", root=str(Path.cwd()), timeout_s=1.5)
     # 仓库 matrix.yaml 目前包含三个示例场景，确保至少调用一次
     assert isinstance(out, dict) and len(out) >= 1
-    assert all(rt == "pr" for _, rt in called)
+    assert all(rt == "pr" for _, rt, _ in called)
+    assert all(ts == 1.5 for _, _, ts in called)


### PR DESCRIPTION
## Summary
- allow `run-matrix` to forward timeout to each scenario execution
- expose `--timeout` option in CLI
- add tests for timeout propagation

## Testing
- `pytest -q -m "not slow"`
- `ruff check src tests`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68c37d014da883218366a65eff21f3ef