### PR TITLE
feat(orchestrator): allow timeout in run-matrix (#18)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,6 +36,9 @@
 - 场景执行顺序：启动→功能→性能→精度→（每日）推送；失败继续，最后汇总
 - PR：默认本地场景；产物保留，不推送指标；性能/精度为精简档（但性能纳入必需门，按基线比对）
 - 每日：K8s 全量矩阵；推送指标并用于 Grafana 展示
+- CLI：
+  - `python -m vllm_cibench.run run --scenario <id> --run-type pr --timeout 60` 执行单场景编排，可自定义探活等待时长。
+  - `python -m vllm_cibench.run run-matrix --run-type pr --timeout 60` 批量执行 `configs/matrix.yaml` 中的所有场景，同样支持自定义探活等待时长。
 
 ## 功能测试要点
 - 覆盖 `/v1/chat/completions` 与 `/v1/completions`；非流式与流式均覆盖；多轮对话（含 `system/assistant` 历史）

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,4 +19,3 @@ typing-extensions>=4.7
 # CLI testing helpers
 typer~=0.12
 requests-mock~=1.12
-types-requests~=2.32

--- a/src/vllm_cibench/orchestrators/run_matrix.py
+++ b/src/vllm_cibench/orchestrators/run_matrix.py
@@ -26,13 +26,14 @@ def scenarios_from_matrix(matrix: Dict[str, object]) -> Iterable[str]:
 
 
 def execute_matrix(
-    run_type: str = "pr", *, root: Optional[str] = None
+    run_type: str = "pr", *, root: Optional[str] = None, timeout_s: float = 60.0
 ) -> Dict[str, object]:
     """执行 matrix 中的所有场景，返回结果映射。
 
     参数:
         run_type: 运行类型（pr/daily）。
         root: 仓库根路径，默认 CWD。
+        timeout_s: 探活最大等待时长（秒），会传递给单场景执行函数。
 
     返回值:
         dict: {scenario_id: result_dict}
@@ -46,6 +47,6 @@ def execute_matrix(
     results: Dict[str, object] = {}
     for sid in scenarios_from_matrix(matrix):
         results[sid] = run_pipeline.execute(
-            scenario_id=sid, run_type=run_type, root=str(base)
+            scenario_id=sid, run_type=run_type, root=str(base), timeout_s=timeout_s
         )
     return results

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -143,8 +143,21 @@ def run_matrix(
     root: Optional[str] = typer.Option(
         None, "--root", help="项目根目录（默认当前工作目录）"
     ),
+    timeout: float = typer.Option(60.0, "--timeout", help="探活最大等待时长（秒）"),
 ) -> None:
-    """批量执行 matrix.yaml 中的所有场景。"""
+    """批量执行 `matrix.yaml` 中的所有场景并输出结果。
 
-    res = run_matrix_mod.execute_matrix(run_type=run_type, root=root)
+    参数:
+        run_type: 运行类型（pr/daily）。
+        root: 项目根目录，缺省为当前工作目录。
+        timeout: 探活最大等待时长（秒）。
+
+    返回值:
+        无返回；以 JSON 打印执行结果到标准输出。
+
+    副作用:
+        读取配置并对每个场景执行集成编排，可能进行网络探活。
+    """
+
+    res = run_matrix_mod.execute_matrix(run_type=run_type, root=root, timeout_s=timeout)
     typer.echo(json.dumps(res, ensure_ascii=False))

--- a/tests/orchestrators/test_run_matrix.py
+++ b/tests/orchestrators/test_run_matrix.py
@@ -8,18 +8,19 @@ import vllm_cibench.orchestrators.run_matrix as rm
 
 
 def test_execute_matrix_calls_pipeline(monkeypatch):
-    """应按 matrix 中的所有场景调用 run_pipeline.execute。"""
+    """应按 matrix 中的所有场景调用 run_pipeline.execute 并传递超时时长。"""
 
     called = []
 
     def fake_execute(
         *, scenario_id: str, run_type: str, root: str, timeout_s: float = 60.0
     ):
-        called.append((scenario_id, run_type))
+        called.append((scenario_id, run_type, timeout_s))
         return {"scenario": scenario_id, "ok": True}
 
     monkeypatch.setattr(rm.run_pipeline, "execute", fake_execute)
-    out = rm.execute_matrix(run_type="pr", root=str(Path.cwd()))
+    out = rm.execute_matrix(run_type="pr", root=str(Path.cwd()), timeout_s=1.5)
     # 仓库 matrix.yaml 目前包含三个示例场景，确保至少调用一次
     assert isinstance(out, dict) and len(out) >= 1
-    assert all(rt == "pr" for _, rt in called)
+    assert all(rt == "pr" for _, rt, _ in called)
+    assert all(ts == 1.5 for _, _, ts in called)

--- a/tests/test_config_and_cli.py
+++ b/tests/test_config_and_cli.py
@@ -8,6 +8,7 @@
 
 import json
 from pathlib import Path
+from typing import Dict
 
 import pytest
 
@@ -26,6 +27,7 @@ if yaml is None:  # pragma: no cover - 缺少依赖时跳过整个模块
 
 from vllm_cibench import config as cfg
 from vllm_cibench.run import app
+import vllm_cibench.run as run_cli
 
 pytestmark = pytest.mark.skipif(CliRunner is None, reason="typer not installed")
 
@@ -90,3 +92,46 @@ def test_scenario_registry_get():
     assert scenario.mode == "local"
     with pytest.raises(KeyError):
         registry.get("not_exists")
+
+
+def test_cli_run_matrix_timeout(monkeypatch: pytest.MonkeyPatch):
+    """校验 run-matrix CLI 能将超时参数传递给执行函数。"""
+
+    called: Dict[str, float] = {}
+
+    def fake_execute_matrix(*, run_type: str, root: str | None, timeout_s: float):
+        called["timeout"] = timeout_s
+        return {}
+
+    monkeypatch.setattr(run_cli.run_matrix_mod, "execute_matrix", fake_execute_matrix)
+    runner = CliRunner()
+    result = runner.invoke(app, ["run-matrix", "--timeout", "2.5"])
+    assert result.exit_code == 0, result.output
+    assert called["timeout"] == 2.5
+
+
+def test_cli_run_timeout(monkeypatch: pytest.MonkeyPatch):
+    """校验 run CLI 能将超时参数传递给执行函数。"""
+
+    called: Dict[str, float] = {}
+
+    def fake_execute(
+        *, scenario_id: str, run_type: str, root: str | None, timeout_s: float
+    ):
+        called["timeout"] = timeout_s
+        return {}
+
+    monkeypatch.setattr(run_cli.run_pipeline, "execute", fake_execute)
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--scenario",
+            "local_single_qwen3-32b_guided_w8a8",
+            "--timeout",
+            "3.0",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert called["timeout"] == 3.0


### PR DESCRIPTION
## Summary
- allow `run-matrix` to forward timeout to each scenario execution
- expose `--timeout` option in CLI and document usage
- add tests for timeout propagation, including `run` CLI
- remove duplicate `types-requests` entry from dev requirements

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `ruff check src tests`
- `mypy src`
- `pytest -q -m "not slow"`


------
https://chatgpt.com/codex/tasks/task_e_68c37d014da883218366a65eff21f3ef