### PR TITLE
feat: add guarded Pushgateway dry-run support

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Skip Pushgateway push'
+        required: false
+        default: 'false'
 
 jobs:
   run-matrix:
@@ -20,5 +25,11 @@ jobs:
       - name: Run daily matrix
         env:
           PROM_PUSHGATEWAY_URL: ${{ secrets.PROM_PUSHGATEWAY_URL }}
+          DRY_RUN: ${{ github.event.inputs.dry-run }}
+          IS_FORK: ${{ github.event.repository.fork }}
         run: |
-          python -m vllm_cibench.run run-matrix --run-type daily
+          if [[ -z "$PROM_PUSHGATEWAY_URL" || "$IS_FORK" == "true" || "$DRY_RUN" == "true" ]]; then
+            python -m vllm_cibench.run run-matrix --run-type daily --dry-run
+          else
+            python -m vllm_cibench.run run-matrix --run-type daily
+          fi

--- a/src/vllm_cibench/orchestrators/run_matrix.py
+++ b/src/vllm_cibench/orchestrators/run_matrix.py
@@ -26,13 +26,14 @@ def scenarios_from_matrix(matrix: Dict[str, object]) -> Iterable[str]:
 
 
 def execute_matrix(
-    run_type: str = "pr", *, root: Optional[str] = None
+    run_type: str = "pr", *, root: Optional[str] = None, dry_run: bool = False
 ) -> Dict[str, object]:
     """执行 matrix 中的所有场景，返回结果映射。
 
     参数:
         run_type: 运行类型（pr/daily）。
         root: 仓库根路径，默认 CWD。
+        dry_run: 若为 True，则跳过 Pushgateway 指标推送。
 
     返回值:
         dict: {scenario_id: result_dict}
@@ -46,6 +47,9 @@ def execute_matrix(
     results: Dict[str, object] = {}
     for sid in scenarios_from_matrix(matrix):
         results[sid] = run_pipeline.execute(
-            scenario_id=sid, run_type=run_type, root=str(base)
+            scenario_id=sid,
+            run_type=run_type,
+            root=str(base),
+            dry_run=dry_run,
         )
     return results

--- a/src/vllm_cibench/orchestrators/run_pipeline.py
+++ b/src/vllm_cibench/orchestrators/run_pipeline.py
@@ -78,6 +78,7 @@ def execute(
     *,
     root: Optional[str] = None,
     timeout_s: float = 60.0,
+    dry_run: bool = False,
 ) -> Dict[str, Any]:
     """执行编排：探活→功能→性能→（daily）指标推送。
 
@@ -86,6 +87,7 @@ def execute(
         run_type: 运行类型，`pr` 或 `daily`。
         root: 仓库根路径（便于测试传入），默认使用 CWD。
         timeout_s: 探活的最大时长（秒）。
+        dry_run: 若为 True，则跳过 Pushgateway 指标推送。
 
     返回值:
         dict: 汇总结果，包括 `base_url`、`functional` 状态、`perf_metrics` 与 `pushed` 标记等。
@@ -139,7 +141,13 @@ def execute(
             "quant": scenario.quant,
             "scenario": scenario.id,
         }
-        pushed = push_metrics("vllm_cibench", agg, labels=labels, run_type=run_type)
+        pushed = push_metrics(
+            "vllm_cibench",
+            agg,
+            labels=labels,
+            run_type=run_type,
+            dry_run=dry_run,
+        )
         result["pushed"] = bool(pushed)
 
     return result

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -111,6 +111,7 @@ def run(
         None, "--root", help="项目根目录（默认当前工作目录）"
     ),
     timeout: float = typer.Option(60.0, "--timeout", help="探活最大等待时长（秒）"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="跳过 Pushgateway 推送"),
 ) -> None:
     """执行集成编排：探活→功能→性能→（daily）指标推送。
 
@@ -119,6 +120,7 @@ def run(
         run_type: 运行类型（pr/daily）。
         root: 项目根目录，便于在测试中传入固定路径；缺省为 CWD。
         timeout: 探活最大等待时长（秒）。
+        dry_run: 若为 True，则不向 Pushgateway 推送指标。
 
     返回值:
         无返回；以 JSON 打印编排结果到标准输出。
@@ -128,7 +130,11 @@ def run(
     """
 
     res = run_pipeline.execute(
-        scenario_id=scenario, run_type=run_type, root=root, timeout_s=timeout
+        scenario_id=scenario,
+        run_type=run_type,
+        root=root,
+        timeout_s=timeout,
+        dry_run=dry_run,
     )
     typer.echo(json.dumps(res, ensure_ascii=False))
 
@@ -143,8 +149,21 @@ def run_matrix(
     root: Optional[str] = typer.Option(
         None, "--root", help="项目根目录（默认当前工作目录）"
     ),
+    dry_run: bool = typer.Option(False, "--dry-run", help="跳过 Pushgateway 推送"),
 ) -> None:
-    """批量执行 matrix.yaml 中的所有场景。"""
+    """批量执行 `matrix.yaml` 中的所有场景。
 
-    res = run_matrix_mod.execute_matrix(run_type=run_type, root=root)
+    参数:
+        run_type: 运行类型（pr/daily）。
+        root: 项目根目录路径。
+        dry_run: 若为 True，则跳过 Pushgateway 指标推送。
+
+    返回值:
+        无；结果以 JSON 打印到标准输出。
+
+    副作用:
+        对每个场景调用 `run_pipeline.execute`，可能进行网络探活。
+    """
+
+    res = run_matrix_mod.execute_matrix(run_type=run_type, root=root, dry_run=dry_run)
     typer.echo(json.dumps(res, ensure_ascii=False))

--- a/tests/orchestrators/test_run_matrix.py
+++ b/tests/orchestrators/test_run_matrix.py
@@ -13,13 +13,18 @@ def test_execute_matrix_calls_pipeline(monkeypatch):
     called = []
 
     def fake_execute(
-        *, scenario_id: str, run_type: str, root: str, timeout_s: float = 60.0
+        *,
+        scenario_id: str,
+        run_type: str,
+        root: str,
+        timeout_s: float = 60.0,
+        dry_run: bool = False,
     ):
-        called.append((scenario_id, run_type))
+        called.append((scenario_id, run_type, dry_run))
         return {"scenario": scenario_id, "ok": True}
 
     monkeypatch.setattr(rm.run_pipeline, "execute", fake_execute)
-    out = rm.execute_matrix(run_type="pr", root=str(Path.cwd()))
+    out = rm.execute_matrix(run_type="pr", root=str(Path.cwd()), dry_run=True)
     # 仓库 matrix.yaml 目前包含三个示例场景，确保至少调用一次
     assert isinstance(out, dict) and len(out) >= 1
-    assert all(rt == "pr" for _, rt in called)
+    assert all(rt == "pr" and dr is True for _, rt, dr in called)


### PR DESCRIPTION
## Summary
- allow dry-run on `push_metrics` to skip Pushgateway pushes
- wire dry-run flag through pipeline, matrix runner, and CLI
- guard daily workflow to push metrics only when safe

## Testing
- `ruff check --fix src/vllm_cibench/metrics/pushgateway.py src/vllm_cibench/orchestrators/run_pipeline.py src/vllm_cibench/orchestrators/run_matrix.py src/vllm_cibench/run.py tests/metrics/test_pushgateway.py tests/orchestrators/test_run_pipeline.py tests/orchestrators/test_run_matrix.py`
- `mypy src/vllm_cibench`
- `pytest -q -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_68c3a5e0e5f08321ad38a82a7bbe0c72