### PR TITLE
feat(clients): support headers in wait_for_ready

### DIFF
--- a/src/vllm_cibench/clients/http.py
+++ b/src/vllm_cibench/clients/http.py
@@ -47,6 +47,7 @@ def wait_for_ready(
     timeout_seconds: int = 60,
     interval_seconds: float = 1.0,
     success_status: int = 200,
+    headers: Optional[Dict[str, str]] = None,
 ) -> bool:
     """轮询等待目标 URL 就绪（返回期望状态码）。
 
@@ -55,6 +56,7 @@ def wait_for_ready(
         timeout_seconds: 总等待时长上限（秒）。
         interval_seconds: 轮询间隔（秒）。
         success_status: 视为就绪的状态码（默认 200）。
+        headers: 可选的请求头（如鉴权信息）。
 
     返回值:
         bool: 在超时前就绪返回 True，否则 False。
@@ -66,7 +68,11 @@ def wait_for_ready(
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
         try:
-            code, _ = http_get(url, timeout=min(interval_seconds * 2, 5.0))
+            code, _ = http_get(
+                url,
+                timeout=min(interval_seconds * 2, 5.0),
+                headers=headers,
+            )
             if code == success_status:
                 return True
         except requests.RequestException:

--- a/tests/clients/test_http.py
+++ b/tests/clients/test_http.py
@@ -29,6 +29,27 @@ def test_wait_for_ready_eventually_ok(requests_mock, monkeypatch):
     assert wait_for_ready(url, timeout_seconds=10, interval_seconds=0.01)
 
 
+def test_wait_for_ready_with_headers(monkeypatch: pytest.MonkeyPatch):
+    """自定义请求头应被正确传递给 http_get。"""
+
+    captured: Dict[str, str] = {}
+
+    def fake_http_get(url: str, timeout: float, headers=None):
+        captured.update(headers or {})
+        return 204, {}
+
+    monkeypatch.setattr("vllm_cibench.clients.http.http_get", fake_http_get)
+    monkeypatch.setattr("time.sleep", lambda *_args, **_kw: None)
+    ok = wait_for_ready(
+        "http://x",
+        timeout_seconds=1,
+        interval_seconds=0.01,
+        success_status=204,
+        headers={"X-Test": "1"},
+    )
+    assert ok is True and captured.get("X-Test") == "1"
+
+
 class DummyResp:
     def __init__(self, status_code: int):
         self.status_code = status_code


### PR DESCRIPTION
## Summary
- allow passing custom HTTP headers to `wait_for_ready`
- cover header forwarding in `wait_for_ready` via new unit test

## Testing
- `ruff check src/vllm_cibench/clients/http.py tests/clients/test_http.py`
- `mypy src`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3c938d89c832194e4ab2cc6e33b58