### PR TITLE
feat(functional): expand OpenAI coverage for streaming and tools

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 # Test
 pytest~=8.3
 pytest-cov~=5.0
+jsonschema~=4.22
 
 # Lint/format
 ruff~=0.6

--- a/src/vllm_cibench/metrics/pushgateway.py
+++ b/src/vllm_cibench/metrics/pushgateway.py
@@ -11,11 +11,11 @@ import os
 from typing import Dict, Iterable, Mapping, Optional
 
 # isort: off
-from prometheus_client import (
+from prometheus_client import (  # type: ignore[import-not-found]
     CollectorRegistry,
     Gauge,
     push_to_gateway,
-)  # type: ignore
+)
 
 # isort: on
 

--- a/src/vllm_cibench/testsuites/functional.py
+++ b/src/vllm_cibench/testsuites/functional.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, cast
 
 from vllm_cibench.clients.openai_client import OpenAICompatClient
 
@@ -15,17 +15,18 @@ def run_basic_chat(
     model: str,
     messages: List[Mapping[str, Any]],
     **params: Any,
-) -> Dict[str, Any]:
+) -> Dict[str, Any] | List[Dict[str, Any]]:
     """运行最小 Chat Completions 请求并返回响应。
 
     参数:
         client: OpenAI 兼容客户端。
         model: 模型名。
         messages: OpenAI 消息数组。
-        params: 其他请求参数（如 temperature/top_p 等）。
+        params: 其他请求参数（如 temperature/top_p/stream 等）。
 
     返回值:
-        dict: 接口返回的 JSON 响应。
+        当 `stream=False` 时返回单个 JSON 响应；当 `stream=True` 时返
+        回按顺序排列的 chunk 列表。
 
     副作用:
         发起网络请求。
@@ -57,4 +58,5 @@ def run_smoke_suite(
     messages: List[Mapping[str, Any]] = [
         {"role": "user", "content": "Say hello in one word."}
     ]
-    return run_basic_chat(client, model, messages, temperature=0)
+    out = run_basic_chat(client, model, messages, temperature=0)
+    return cast(Dict[str, Any], out)

--- a/tests/testsuites/test_functional_params.py
+++ b/tests/testsuites/test_functional_params.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import json
 
+from jsonschema import validate
+
 from vllm_cibench.clients.openai_client import OpenAICompatClient
 from vllm_cibench.testsuites.functional import run_basic_chat
 
 
 def _fake_resp(content: str = "ok") -> dict:
+    """构造最小成功响应。"""
+
     return {
         "id": "chatcmpl-xyz",
         "object": "chat.completion",
@@ -19,6 +23,37 @@ def _fake_resp(content: str = "ok") -> dict:
                 "index": 0,
                 "message": {"role": "assistant", "content": content},
                 "finish_reason": "stop",
+            }
+        ],
+    }
+
+
+def _fake_tool_resp() -> dict:
+    """构造包含 tool_calls 的响应体。"""
+
+    return {
+        "id": "chatcmpl-xyz",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"beijing"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
             }
         ],
     }
@@ -63,6 +98,34 @@ def test_response_format_json(requests_mock):
     assert out["choices"][0]["message"]["content"] == "{}"
 
 
+def test_response_format_json_schema(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    content = json.dumps({"city": "beijing"})
+    requests_mock.post(url, json=_fake_resp(content), status_code=200)
+
+    schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "hi"}],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "City", "schema": schema},
+        },
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["response_format"]["type"] == "json_schema"
+    data = json.loads(out["choices"][0]["message"]["content"])
+    validate(instance=data, schema=schema)
+
+
 def test_function_call_tools(requests_mock):
     base = "http://example.com/v1"
     url = base + "/chat/completions"
@@ -94,3 +157,37 @@ def test_function_call_tools(requests_mock):
     body = json.loads(requests_mock.request_history[0].text)
     assert body["tools"][0]["function"]["name"] == "get_weather"
     assert body["tool_choice"] == "auto"
+
+
+def test_function_call_tool_choice_required(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    requests_mock.post(url, json=_fake_tool_resp(), status_code=200)
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather by city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        tool_choice="required",
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["tool_choice"] == "required"
+    name = out["choices"][0]["message"]["tool_calls"][0]["function"]["name"]
+    assert name == "get_weather"


### PR DESCRIPTION
## Summary
- support streaming chat completions in OpenAICompatClient
- exercise stream, multi-turn, json schema, and tool_choice scenarios in tests
- validate JSON schema via jsonschema dependency

## Testing
- `ruff check src/vllm_cibench/clients/openai_client.py tests/testsuites/test_functional.py tests/testsuites/test_functional_params.py src/vllm_cibench/metrics/pushgateway.py src/vllm_cibench/testsuites/functional.py`
- `mypy src`
- `pytest -m "not slow"`


------
https://chatgpt.com/codex/tasks/task_e_68c3ca89adec8321b2b336808c015add