### PR TITLE
fix(k8s): allow node port override with clear errors

### DIFF
--- a/src/vllm_cibench/deploy/k8s/__init__.py
+++ b/src/vllm_cibench/deploy/k8s/__init__.py
@@ -1,1 +1,34 @@
 """Kubernetes 部署与探活适配层。"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+from ...config import Scenario
+
+
+def k8s_params_from_scenario(
+    s: Scenario,
+) -> Tuple[str, str, str, str, Optional[int]]:
+    """从场景提取 K8s 访问所需参数。"
+
+    参数:
+        s: 场景对象，``raw.k8s`` 中包含 ``namespace``/``service_name``/``port_name``/``node_port``。
+
+    返回值:
+        Tuple[str, str, str, str, Optional[int]]: ``(namespace, service_name, port_name, path_prefix, node_port)``。
+
+    副作用:
+        无。
+    """
+
+    k8s: Dict[str, object] = s.raw.get("k8s", {}) or {}
+    namespace = str(k8s.get("namespace", "default"))
+    service_name = str(k8s.get("service_name"))
+    port_name = str(k8s.get("port_name", "http"))
+    node_port_val = k8s.get("node_port")
+    node_port = int(node_port_val) if isinstance(node_port_val, (int, str)) else None
+    path_prefix = str(s.raw.get("base_path", "/v1"))
+    if not service_name:
+        raise KeyError("scenario.k8s.service_name is required for k8s modes")
+    return namespace, service_name, port_name, path_prefix, node_port

--- a/src/vllm_cibench/deploy/k8s/hybrid.py
+++ b/src/vllm_cibench/deploy/k8s/hybrid.py
@@ -1,6 +1,4 @@
-"""K8s Hybrid 部署适配（通过 NodePort 直连）。
-
-基于场景配置中的 `k8s.{namespace, service_name, port_name}` 字段，
+"""基于场景配置中的 `k8s.{namespace, service_name, port_name}` 字段，
 发现可访问的 `base_url` 并进行健康探活。
 """
 
@@ -8,33 +6,9 @@ from __future__ import annotations
 
 # isort: skip_file
 
-from typing import Dict, Tuple
-
 from ...config import Scenario
+from . import k8s_params_from_scenario
 from .kubernetes_client import discover_service_base_url, wait_k8s_service_ready
-
-
-def _k8s_params_from_scenario(s: Scenario) -> Tuple[str, str, str, str]:
-    """从场景对象提取 K8s 必需参数。
-
-    参数:
-        s: `Scenario` 对象，`raw.k8s` 中包含 `namespace/service_name/port_name`。
-
-    返回值:
-        (namespace, service_name, port_name, path_prefix)
-
-    副作用:
-        无。
-    """
-
-    k8s: Dict[str, object] = s.raw.get("k8s", {}) or {}
-    namespace = str(k8s.get("namespace", "default"))
-    service_name = str(k8s.get("service_name"))
-    port_name = str(k8s.get("port_name", "http"))
-    path_prefix = str(s.raw.get("base_path", "/v1"))
-    if not service_name:
-        raise KeyError("scenario.k8s.service_name is required for k8s-hybrid mode")
-    return namespace, service_name, port_name, path_prefix
 
 
 def discover_base_url(s: Scenario, incluster: bool = False) -> str:
@@ -51,13 +25,14 @@ def discover_base_url(s: Scenario, incluster: bool = False) -> str:
         调用 K8s API 进行资源发现。
     """
 
-    ns, svc, port, prefix = _k8s_params_from_scenario(s)
+    ns, svc, port, prefix, node_port = k8s_params_from_scenario(s)
     return discover_service_base_url(
         namespace=ns,
         service_name=svc,
         port_name=port,
         path_prefix=prefix,
         incluster=incluster,
+        node_port=node_port,
     )
 
 
@@ -82,7 +57,7 @@ def wait_ready(
         调用 K8s API 与 HTTP 探活。
     """
 
-    ns, svc, port, prefix = _k8s_params_from_scenario(s)
+    ns, svc, port, prefix, node_port = k8s_params_from_scenario(s)
     return wait_k8s_service_ready(
         namespace=ns,
         service_name=svc,
@@ -91,4 +66,5 @@ def wait_ready(
         timeout_s=timeout_s,
         interval_s=interval_s,
         incluster=incluster,
+        node_port=node_port,
     )

--- a/src/vllm_cibench/deploy/k8s/pd.py
+++ b/src/vllm_cibench/deploy/k8s/pd.py
@@ -1,6 +1,4 @@
-"""K8s PD（Pipeline/Prefill/Decode 分离）部署适配。
-
-从场景配置中解析 PD 专属参数（scheduler/prefill/decode），
+"""从场景配置中解析 PD 专属参数（scheduler/prefill/decode），
 并基于统一的 Service 发现逻辑获取对外 `base_url` 与探活能力。
 """
 
@@ -8,43 +6,21 @@ from __future__ import annotations
 
 # isort: skip_file
 
-from typing import Dict, Tuple
+from typing import Dict
 
 from ...config import Scenario
+from . import k8s_params_from_scenario
 from .kubernetes_client import discover_service_base_url, wait_k8s_service_ready
-
-
-def _k8s_params_from_scenario(s: Scenario) -> Tuple[str, str, str, str]:
-    """提取用于服务发现的 K8s 参数。
-
-    参数:
-        s: 场景对象，`raw.k8s` 中包含 `namespace/service_name/port_name`。
-
-    返回值:
-        (namespace, service_name, port_name, path_prefix)
-
-    副作用:
-        无。
-    """
-
-    k8s: Dict[str, object] = s.raw.get("k8s", {}) or {}
-    namespace = str(k8s.get("namespace", "default"))
-    service_name = str(k8s.get("service_name"))
-    port_name = str(k8s.get("port_name", "http"))
-    path_prefix = str(s.raw.get("base_path", "/v1"))
-    if not service_name:
-        raise KeyError("scenario.k8s.service_name is required for k8s-pd mode")
-    return namespace, service_name, port_name, path_prefix
 
 
 def _pd_params_from_scenario(s: Scenario) -> Dict[str, str]:
     """提取 PD 参数（scheduler/prefill/decode）。
 
     参数:
-        s: 场景对象，`raw.pd` 中包含三段参数字符串。
+        s: 场景对象，``raw.pd`` 中包含三段参数字符串。
 
     返回值:
-        dict: {'scheduler_params': str, 'prefill_params': str, 'decode_params': str}
+        dict: ``{"scheduler_params": str, "prefill_params": str, "decode_params": str}``。
 
     副作用:
         无。
@@ -66,7 +42,7 @@ def build_pd_args(s: Scenario) -> Dict[str, str]:
         s: 场景对象。
 
     返回值:
-        dict: 同 `_pd_params_from_scenario` 的输出。
+        dict: 同 ``_pd_params_from_scenario`` 的输出。
 
     副作用:
         无。
@@ -83,19 +59,20 @@ def discover_base_url(s: Scenario, incluster: bool = False) -> str:
         incluster: 是否使用容器内配置。
 
     返回值:
-        str: 形如 `http://<node_ip>:<node_port>/v1`。
+        str: 形如 ``http://<node_ip>:<node_port>/v1``。
 
     副作用:
         调用 K8s API 进行资源发现。
     """
 
-    ns, svc, port, prefix = _k8s_params_from_scenario(s)
+    ns, svc, port, prefix, node_port = k8s_params_from_scenario(s)
     return discover_service_base_url(
         namespace=ns,
         service_name=svc,
         port_name=port,
         path_prefix=prefix,
         incluster=incluster,
+        node_port=node_port,
     )
 
 
@@ -120,7 +97,7 @@ def wait_ready(
         调用 K8s API 与 HTTP 探活。
     """
 
-    ns, svc, port, prefix = _k8s_params_from_scenario(s)
+    ns, svc, port, prefix, node_port = k8s_params_from_scenario(s)
     return wait_k8s_service_ready(
         namespace=ns,
         service_name=svc,
@@ -129,4 +106,5 @@ def wait_ready(
         timeout_s=timeout_s,
         interval_s=interval_s,
         incluster=incluster,
+        node_port=node_port,
     )

--- a/tests/deploy/k8s/test_kubernetes_client.py
+++ b/tests/deploy/k8s/test_kubernetes_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace as NS
+from typing import Dict
 
 import pytest
 
@@ -50,7 +51,7 @@ def test_wait_k8s_service_ready(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(
         kc, "create_core_v1_api", lambda incluster=False: FakeCoreV1Api()
     )
-    called = {"url": None}
+    called: Dict[str, str] = {"url": ""}
 
     def fake_wait(url: str, timeout_s: float, max_attempts: int) -> bool:
         called["url"] = url
@@ -62,3 +63,64 @@ def test_wait_k8s_service_ready(monkeypatch: pytest.MonkeyPatch):
     )
     assert ok is True
     assert called["url"] == "http://10.0.0.1:30000/v1"
+
+
+def test_discover_with_node_port_override(monkeypatch: pytest.MonkeyPatch):
+    """显式 node_port 时不应调用 Service 端口解析。"""
+
+    monkeypatch.setattr(
+        kc, "create_core_v1_api", lambda incluster=False: FakeCoreV1Api()
+    )
+    called = {"svc": 0}
+
+    def fake_get_port(*_a, **_kw):
+        called["svc"] += 1
+        return 30000
+
+    monkeypatch.setattr(kc, "_get_service_node_port", fake_get_port)
+    url = kc.discover_service_base_url(
+        namespace="default",
+        service_name="infer-vllm",
+        node_port=31000,
+    )
+    assert url == "http://10.0.0.1:31000/v1"
+    assert called["svc"] == 0
+
+
+class NoServiceApi(FakeCoreV1Api):
+    def read_namespaced_service(self, name: str, namespace: str):  # pragma: no cover
+        raise Exception("not found")
+
+
+def test_service_missing(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        kc, "create_core_v1_api", lambda incluster=False: NoServiceApi()
+    )
+    with pytest.raises(RuntimeError, match="Service not found"):
+        kc.discover_service_base_url("d", "svc")
+
+
+class PortMismatchApi(FakeCoreV1Api):
+    def read_namespaced_service(self, name: str, namespace: str):  # pragma: no cover
+        port = NS(name="metrics", node_port=30000)
+        spec = NS(ports=[port])
+        return NS(spec=spec)
+
+
+def test_port_name_mismatch(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        kc, "create_core_v1_api", lambda incluster=False: PortMismatchApi()
+    )
+    with pytest.raises(RuntimeError, match="port name 'http' not found"):
+        kc.discover_service_base_url("d", "svc", port_name="http")
+
+
+class NoNodeApi(FakeCoreV1Api):
+    def list_node(self):  # pragma: no cover
+        return NS(items=[])
+
+
+def test_no_node(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(kc, "create_core_v1_api", lambda incluster=False: NoNodeApi())
+    with pytest.raises(RuntimeError, match="No node InternalIP found"):
+        kc.discover_service_base_url("d", "svc")


### PR DESCRIPTION
## Summary
- unify k8s scenario parsing with optional `node_port`
- improve kubernetes client error messages and node port override
- cover node port overrides and error branches in hybrid/PD adapters

## Testing
- `ruff check src/vllm_cibench/deploy/k8s/__init__.py src/vllm_cibench/deploy/k8s/hybrid.py src/vllm_cibench/deploy/k8s/kubernetes_client.py src/vllm_cibench/deploy/k8s/pd.py tests/deploy/k8s/test_hybrid.py tests/deploy/k8s/test_kubernetes_client.py tests/deploy/k8s/test_pd.py`
- `mypy src/vllm_cibench/deploy/k8s/__init__.py src/vllm_cibench/deploy/k8s/hybrid.py src/vllm_cibench/deploy/k8s/kubernetes_client.py src/vllm_cibench/deploy/k8s/pd.py tests/deploy/k8s/test_hybrid.py tests/deploy/k8s/test_kubernetes_client.py tests/deploy/k8s/test_pd.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3cfd6d1e883219613460754b106b5