### PR TITLE
ci: add orchestrator smoke dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,35 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -r requirements-dev.txt
       - run: pytest -q
+      - name: orchestrator smoke (dry run)
+        run: |
+          python - <<'PY'
+import shutil, yaml
+from pathlib import Path
+src = Path('configs')
+dst = Path('smoke_configs')
+shutil.copytree(src, dst, dirs_exist_ok=True)
+matrix = yaml.safe_load((src / 'matrix.yaml').read_text())
+keep = 'local_single_qwen3-32b_guided_w8a8'
+matrix = {keep: matrix[keep]}
+(dst / 'matrix.yaml').write_text(yaml.safe_dump(matrix))
+PY
+          PYTHONPATH=src python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --root smoke_configs --dry-run > smoke_run.json
+          PYTHONPATH=src python -m vllm_cibench.run run-matrix --run-type pr --root smoke_configs --dry-run > smoke_matrix.json
+          cat smoke_run.json
+          cat smoke_matrix.json
+          python - <<'PY'
+import json, os
+run = json.load(open('smoke_run.json'))
+matrix = json.load(open('smoke_matrix.json'))
+lines = [f"single: func={run.get('functional')}, perf={bool(run.get('perf_metrics'))}"]
+for sid, res in matrix.items():
+    lines.append(f"{sid}: func={res.get('functional')}, perf={bool(res.get('perf_metrics'))}")
+summary = '\n'.join(f"- {l}" for l in lines)
+with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
+    fh.write('### Orchestrator Smoke\n')
+    fh.write(summary + '\n')
+PY
 
   gate:
     name: gate

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -139,10 +139,6 @@ def run(
     typer.echo(json.dumps(res, ensure_ascii=False))
 
 
-if __name__ == "__main__":
-    main()
-
-
 @app.command("run-matrix")
 def run_matrix(
     run_type: str = typer.Option("pr", "--run-type", help="运行类型: pr/daily"),
@@ -167,3 +163,7 @@ def run_matrix(
 
     res = run_matrix_mod.execute_matrix(run_type=run_type, root=root, dry_run=dry_run)
     typer.echo(json.dumps(res, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_run_matrix.py
+++ b/tests/test_cli_run_matrix.py
@@ -1,0 +1,27 @@
+"""CLI run-matrix 子命令测试。"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from typer.testing import CliRunner
+
+from vllm_cibench.run import app
+
+
+def test_cli_run_matrix_dry_run(monkeypatch) -> None:
+    """校验 run-matrix 子命令在 dry-run 下返回 JSON。"""
+
+    def fake_execute_matrix(*_args: Any, **_kwargs: Any) -> Dict[str, str]:
+        return {"dummy": "ok"}
+
+    monkeypatch.setattr(
+        "vllm_cibench.orchestrators.run_matrix.execute_matrix", fake_execute_matrix
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["run-matrix", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    obj = json.loads(result.stdout.strip())
+    assert obj == {"dummy": "ok"}


### PR DESCRIPTION
## Summary
- ensure `run-matrix` CLI command is registered before `main`
- add a dry-run orchestrator smoke step to PR CI
- cover `run-matrix` CLI via unit test

## Testing
- `ruff check src tests`
- `black --check src tests`
- `isort --check-only src tests`
- `mypy --ignore-missing-imports src`
- `pytest -q -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_68c3d9ab9be083218038d91f2b24782a