### PR TITLE
feat(functional,validation): add completions API and basic tests; register markers

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-functional-coverage-and-params.md
+++ b/.github/ISSUE_TEMPLATE/5-functional-coverage-and-params.md
@@ -1,0 +1,65 @@
+---
+name: "feat: Functional Coverage + Param Validation"
+about: "Expand VLLM feature tests for chat/completions and add parameter validity tests"
+title: "feat(functional,validation): expand coverage for chat/completions and add param validation"
+labels: ["feat", "functional", "validation", "testing"]
+assignees: []
+---
+
+## 背景
+现有功能性测试覆盖了基础 chat、部分流式/工具/JSON schema 等，但仍有大量 VLLM 参数与场景未覆盖，且缺少系统性的参数合法性（类型/边界）测试。
+
+## 目标
+- 扩展功能测试：覆盖 chat/completions 端点的大部分常用/边界参数与组合场景。
+- 新增参数合法性测试：对类型错误、越界取值的 4xx 响应及错误消息传播进行断言。
+- 所有用例均使用 `requests-mock` 或 `monkeypatch`，不依赖真实网络。
+
+## 详细需求
+1) 客户端能力
+   - 在 `src/vllm_cibench/clients/openai_client.py` 新增 `completions()` 方法，接口风格与 `chat_completions()` 一致，支持 `stream` 与 `logprobs/top_logprobs`（若 stream=false）。
+   - 在 `src/vllm_cibench/testsuites/functional.py` 新增或重构公共调用函数：`run_basic_completion()`，以及共享断言工具。
+
+2) Chat 端点覆盖（tests/testsuites/test_functional_chat_ext.py）
+   - multi-turn 与 system 提示；`n` 多样本返回。
+   - 流式（SSE）：chunk 结构、`[DONE]` 终止。
+   - response_format：`json_object`、`json_schema`（含 schema 校验）。
+   - Tools/Function call：`tool_choice=none/auto/required`、按函数名强制调用；并行多 `tool_calls`。
+   - 采样与约束：`temperature/top_p/top_k` 极值；`stop`/`stop_token_ids`；`logit_bias`；`presence_penalty`、`frequency_penalty`；`seed`；`max_tokens`；（若支持）`use_beam_search`、`length_penalty`、`early_stopping`。
+
+3) Completions 端点覆盖（tests/testsuites/test_functional_completions.py）
+   - `prompt`/`suffix`/`echo`；`n` 多样本；`logprobs`/`top_logprobs`；`best_of`（若服务支持）。
+
+4) 参数合法性（tests/testsuites/test_functional_params_negative.py）
+   - 类型错误：布尔/字符串/列表互换导致的 400/422；
+   - 越界值：`top_p<0或>1`、`temperature<0`、`top_k<0`、`n<=0`、`max_tokens<0`、penalty 超范围等；
+   - 断言：客户端抛出 `requests.HTTPError` 或返回体包含错误消息，确保错误传播链条正确。
+
+5) 配置与标记
+   - 为新增用例添加 `@pytest.mark.functional` 标记；在 `pytest.ini` 注册（若尚未）。
+   - （可选）`configs/tests/functional.yaml` 添加开关项，以便在编排中选择子集参数覆盖。
+
+## 修改点（文件/代码）
+- `src/vllm_cibench/clients/openai_client.py`：新增 `completions()`；
+- `src/vllm_cibench/testsuites/functional.py`：新增 `run_basic_completion()` 与通用断言；
+- `tests/testsuites/test_functional_chat_ext.py`、`test_functional_completions.py`、`test_functional_params_negative.py`（新增）；
+- （可选）`configs/tests/functional.yaml`（新增）；`pytest.ini` 注册 markers。
+
+## 测试用例（必须）
+- 正常路径：chat/completions 各参数与典型组合；
+- 负路径：参数类型/范围非法返回 4xx；
+- 流式：SSE 分块解析与结束标志；
+- `n`/多样本一致性、`logprobs` 结构完整性（当请求时）。
+
+## 命令与验证
+- `pytest -q -m "functional"`
+- `pytest -q` 全量；CI 时长控制在可接受范围。
+
+## 验收标准
+- 新增功能性用例数 ≥20；整体覆盖率维持 ≥85%。
+- 关键参数的非法输入路径被覆盖并断言错误传播行为。
+
+## 参考实现要点（指导 Codex Cloud）
+- 始终以 `requests-mock` 截获 HTTP，断言请求体参数与响应解析。
+- 对 4xx 使用 `requests_mock.post(..., status_code=400, json={"error":{...}})` 并 `resp.raise_for_status()` 触发异常路径测试。
+- 流式用 `content=` 伪造 `text/event-stream`，包含多条 `data:` 与最终 `[DONE]` 行。
+

--- a/docs/DESIGN_TODO.md
+++ b/docs/DESIGN_TODO.md
@@ -1,0 +1,120 @@
+# 设计指导书 TODO（vLLM CI Bench 后续工作）
+
+本文件列出当前仓库尚未覆盖或需要完善的功能，并拆分为可独立提交的 PR/Issue。每一项包含范围、验收标准、修改点、测试与验证命令，便于 Codex Cloud 或贡献者直接跟进实现。
+
+## 里程碑 M1：打通 Accuracy 流程（GPQA as default）
+
+- 范围
+  - 新增 `accuracy` 执行器：默认集成 Simple-Evals 的 GPQA（可配置），以 OpenAI 兼容 REST 调用待测服务，统计分数与失败样本。
+  - 在 `run_pipeline.execute` 中串联 `accuracy` 阶段：当 `matrix.yaml` 对应场景 `accuracy: true` 时执行。
+  - 结果汇总到 `run`/`run-matrix` 的 JSON 输出中（字段示例：`{"accuracy": {"task": "gpqa", "score": 0.52}}`）。
+- 修改点
+  - `src/vllm_cibench/testsuites/accuracy.py`（新文件）：实现 `run_accuracy(base_url, model, cfg)` 最小版本（允许 mock/子集评测）。
+  - `src/vllm_cibench/orchestrators/run_pipeline.py`：在 perf 后追加 accuracy；`result["accuracy"]` 字段落盘。
+  - `configs/tests/accuracy.yaml`（新文件）：默认任务 GPQA，允许切换数据集与 provider。
+  - `README.md`：补充 accuracy 相关说明与示例命令。
+- 验收标准
+  - 单元/系统测试覆盖率保持 ≥85%。
+  - `python -m vllm_cibench.run run --scenario <任一场景> --run-type pr --dry-run` 输出包含 `accuracy` 字段（在测试中可使用 mock）。
+- 测试与验证
+  - `pytest -q -m "not slow"`
+  - `python -m vllm_cibench.run plan --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr`
+  - `python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run`
+
+## 里程碑 M2：完善配置与工具目录（configs/tests、configs/deploy、tools/）
+
+- 范围
+  - 新增 `configs/tests/`：拆分功能/性能/精度套件参数（例如 chat 输入模版、响应格式校验开关、perf 并发/长度矩阵、accuracy 数据集选择）。
+  - 新增 `configs/deploy/`：提供 K8s 示例（`infer_vllm_kubeinfer.yaml`）与本地启动示意参数。
+  - 新增 `tools/`：
+    - `acs_bench_mock.py`：命令行输出带表头的 CSV（与 `testsuites/perf.py` 字段对齐）。
+    - `metrics_rename.py`：读取 CSV/JSON，输出 Prometheus 规范键名（复用 `metrics/rename.py`）。
+    - `gen_*_yaml`：生成场景/测试样例 YAML 的脚手架。
+- 修改点
+  - `README.md`：文档链接与使用示例。
+- 验收标准
+  - 本地可运行工具脚本并生成示例输出；对应最小单元测试覆盖基本 I/O。
+
+## 里程碑 M3：脚本与测试标记（scripts/*、pytest markers）
+
+- 范围
+  - 新增 `scripts/deploy_k8s.sh`：对 `configs/deploy/*.yaml` 执行 `kubectl apply` 与简单探活提示。
+  - 新增 `scripts/collect_and_push.sh`：从性能 CSV 聚合并调用 Python API 推送（保留 `--dry-run`），与 Pushgateway 条件一致。
+  - 为现有测试添加 markers：`functional`、`perf`、`accuracy`、`integration`、`slow`；在 `pytest.ini` 注册。
+- 验收标准
+  - `pytest -m functional`、`pytest -m perf` 等子集可运行。
+  - 脚本具备帮助信息与失败退出码。
+
+## 里程碑 M4：类型与风格（mypy --strict、ruff）
+
+- 范围
+  - 修复 `mypy --strict src` 报告的问题（返回值/参数注解、移除无用 ignore）。
+  - CI 中开启 `ruff check` 与 `mypy`（作为非阻断可先 WARNING，再逐步提升为必过）。
+- 参考当前 mypy 报告（需修复示例）
+  - `config.py`: `Unused "type: ignore"`、`no-any-return`。
+  - `metrics/pushgateway.py`: `Unused "type: ignore"`。
+  - `clients/*`: `Unused "type: ignore"`、`no-any-return`。
+  - `deploy/local.py`: `Popen` 类型参数。
+  - `deploy/k8s/kubernetes_client.py`: 缺少返回/参数注解。
+  - `run.py`: `Unused "type: ignore"`。
+- 验收标准
+  - `mypy --strict src` 0 error（或在 PR1 降低为最小可用集）。
+
+---
+
+## 里程碑 M5：功能性覆盖与参数合法性验证（Functional + Param Validation）
+
+- 范围
+  - 扩展 OpenAI 兼容功能用例覆盖：chat/completions 端点更全面参数与组合场景。
+  - 参数合法性验证：类型与取值边界（含负值、超上限、空/None、错误类型）。
+  - 新增 `OpenAICompatClient.completions()`；新增 `run_basic_completion()`（或统一封装）。
+  - 测试用例全部使用 `requests-mock`，不依赖真实网络；对非法参数以 mock 400/422 响应覆盖错误路径。
+
+- 覆盖点建议（不局限于此）
+  - Chat 端点：
+    - 基本/多轮对话、`system` 提示、`n` 多样本。
+    - 流式（SSE）chunk 结构与 `[DONE]` 终止。
+    - `response_format`：`json_object`、`json_schema`（schema 验证）。
+    - Tools/Function call：`tool_choice=none/auto/required`、按函数名指定、并行多 tool_calls。
+    - Reasoning：`reasoning=True` 字段解析已覆盖，补充边界（无字段/空值）。
+    - 采样与约束：`temperature/top_p/top_k` 极值、`stop`/`stop_token_ids`、`logit_bias`、`presence_penalty`、`frequency_penalty`、`seed`、`max_tokens`、`use_beam_search`、`length_penalty`、`early_stopping`（若服务支持）。
+  - Completions 端点：
+    - `prompt`/`suffix`/`echo`、`n`、`logprobs`/`top_logprobs`、`best_of`（若支持）。
+  - 参数合法性（统一分组断言 400）：
+    - 类型错误：字符串传布尔、列表传整型等。
+    - 取值越界：`top_p<0或>1`、`temperature<0`、`top_k<0`、`n<=0`、`max_tokens<0`、penalty 超范围等。
+
+- 修改点
+  - `src/vllm_cibench/clients/openai_client.py`：新增 `completions()`。
+  - `src/vllm_cibench/testsuites/functional.py`：新增/重构 `run_basic_completion()` 与公共断言。
+  - `tests/testsuites/`：新增 `test_functional_completions.py`、`test_functional_params_negative.py` 等。
+  -（可选）`configs/tests/functional.yaml`：开关与样例参数集。
+
+- 验收标准
+  - 新增用例数 ≥20，覆盖上述大部分维度；整体覆盖率保持 ≥85%。
+  - 非法参数路径以 mock 400 响应覆盖（断言错误码/错误消息传播）。
+
+- 测试与验证
+  - `pytest -q -m "functional"`（添加 markers 后）。
+  - `pytest -q` 全绿；CI 时长可控。
+
+## PR 切分建议（每 PR 控制粒度，可评审）
+
+1) feat(accuracy): add accuracy runner and pipeline wiring
+   - 仅新增 `testsuites/accuracy.py` 与 `run_pipeline` 串联、最小配置与测试。
+2) feat(configs/tools): add configs/tests/*, configs/deploy/*, tools/*
+   - 仅新增目录与工具脚本+对应单测，不改核心逻辑。
+3) chore(scripts/markers): add scripts/* and pytest markers
+   - 仅新增脚本与测试标记、pytest.ini 注册。
+4) chore(types): fix mypy --strict issues and enable lint in CI
+   - 仅类型与风格修复，CI 工作流补充检查环节。
+
+## 验证与回归
+
+- 核心命令
+  - `python -m vllm_cibench.run plan --scenario <s> --run-type pr`
+  - `python -m vllm_cibench.run run --scenario <s> --run-type pr --dry-run`
+  - `python -m vllm_cibench.run run-matrix --run-type pr --dry-run`
+- Pushgateway（仅 daily 且设置 URL）
+  - `export PROM_PUSHGATEWAY_URL=http://pushgw:9091`
+  - `python -m vllm_cibench.run run --scenario <s> --run-type daily`（或 `--dry-run`）

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,10 @@
 [pytest]
 addopts = -q
 testpaths = tests
+markers =
+    functional: Functional tests for API behavior
+    perf: Performance-related tests
+    accuracy: Accuracy/eval tests
+    integration: Integration/system tests
+    slow: Slow-running tests
+    validation: Parameter validation and negative-path tests

--- a/src/vllm_cibench/testsuites/functional.py
+++ b/src/vllm_cibench/testsuites/functional.py
@@ -86,3 +86,31 @@ def get_reasoning(out: Mapping[str, Any], key: str = "reasoning_content") -> str
     if key not in message:
         raise KeyError(f"reasoning key not found: {key}")
     return str(message[key])
+
+
+def run_basic_completion(
+    base_url: str,
+    model: str,
+    prompt: str,
+    api_key: Optional[str] = None,
+    **params: Any,
+) -> Dict[str, Any] | List[Dict[str, Any]]:
+    """执行基础文本补全（/v1/completions）。
+
+    参数:
+        base_url: 服务基础 URL，例如 `http://127.0.0.1:9000/v1`。
+        model: 模型名。
+        prompt: 文本补全提示词。
+        api_key: 可选 API Key。
+        params: 其他请求参数（如 temperature/top_p/stream 等）。
+
+    返回值:
+        当 `stream=False` 时返回单个 JSON 响应；当 `stream=True` 时返
+        回按顺序排列的 chunk 列表。
+
+    副作用:
+        发起网络请求。
+    """
+
+    client = OpenAICompatClient(base_url=base_url, api_key=api_key)
+    return client.completions(model=model, prompt=prompt, **params)

--- a/tests/testsuites/test_functional_completions.py
+++ b/tests/testsuites/test_functional_completions.py
@@ -1,0 +1,50 @@
+"""Completions 端点功能测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_cibench.testsuites.functional import run_basic_completion
+
+
+@pytest.mark.functional
+def test_completions_basic(requests_mock):
+    """基础 completions：应返回 choices[0].text。"""
+
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    payload = {
+        "id": "cmpl-xyz",
+        "object": "text_completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [{"index": 0, "text": "Hello", "finish_reason": "stop"}],
+    }
+    requests_mock.post(url, json=payload, status_code=200)
+
+    out = run_basic_completion(base_url=base, model="dummy", prompt="Hi")
+    assert out["choices"][0]["text"] == "Hello"
+
+
+@pytest.mark.functional
+def test_completions_stream(requests_mock):
+    """stream 模式应返回按顺序排列的 chunk（text 字段）。"""
+
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    content = (
+        'data: {"choices":[{"index":0,"text":"He"}]}\n\n'
+        'data: {"choices":[{"index":0,"text":"llo"}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    requests_mock.post(
+        url,
+        content=content.encode(),
+        headers={"Content-Type": "text/event-stream"},
+        status_code=200,
+    )
+
+    out = run_basic_completion(base_url=base, model="dummy", prompt="Hi", stream=True)
+    assert isinstance(out, list) and len(out) == 2
+    assert out[0]["choices"][0]["text"] == "He"
+    assert out[1]["choices"][0]["text"] == "llo"

--- a/tests/testsuites/test_functional_params_negative.py
+++ b/tests/testsuites/test_functional_params_negative.py
@@ -1,0 +1,50 @@
+"""参数合法性（负路径）测试。"""
+
+# isort: skip_file
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat, run_basic_completion
+
+
+@pytest.mark.functional
+@pytest.mark.validation
+def test_chat_invalid_top_p_raises_http_error(requests_mock):
+    """非法 top_p 应返回 4xx 并触发 HTTPError。"""
+
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    err = {"error": {"message": "invalid top_p"}}
+    requests_mock.post(url, json=err, status_code=400)
+
+    client = OpenAICompatClient(base_url=base)
+    with pytest.raises(requests.HTTPError):
+        _ = run_basic_chat(
+            client,
+            model="dummy",
+            messages=[{"role": "user", "content": "hi"}],
+            top_p=1.5,
+        )
+
+
+@pytest.mark.functional
+@pytest.mark.validation
+def test_completions_negative_max_tokens(requests_mock):
+    """负数 max_tokens 应返回 4xx 并触发 HTTPError。"""
+
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    err = {"error": {"message": "max_tokens must be >= 0"}}
+    requests_mock.post(url, json=err, status_code=422)
+
+    with pytest.raises(requests.HTTPError):
+        _ = run_basic_completion(
+            base_url=base,
+            model="dummy",
+            prompt="Hello",
+            max_tokens=-1,
+        )


### PR DESCRIPTION
### 目标
- [x] 本 PR 的范围清晰、粒度可评审（功能覆盖增强：completions API + 基础正/负路径用例，注册 markers）
- [x] 本地 `pytest` 全绿；CI 全绿

### TDD 证明
- [x] 先提交了测试（使本地/CI 变红）
- [x] 再提交实现（使本地/CI 变绿）

### 变更内容
- 新增 `OpenAICompatClient.completions()`，支持 stream 与非流式，接口与 `chat_completions()` 对齐。
- 新增 `run_basic_completion()` 封装，便于系统测试复用。
- 新增功能性测试：
  - `tests/testsuites/test_functional_completions.py`：基础返回结构、SSE 流式 chunk 顺序与结束标志断言。
- 新增参数合法性（负路径）测试：
  - `tests/testsuites/test_functional_params_negative.py`：
    - chat 非法 `top_p` → 400/HTTPError；
    - completions 负数 `max_tokens` → 422/HTTPError；
- 注册 pytest markers：`functional`、`validation` 等于 `pytest.ini`。

### 复现实验命令
```bash
# 安装
python3 -m venv .venv && source .venv/bin/activate
pip install -r requirements-dev.txt

# 测试（CI 同步）
pytest -q -m "not slow"
ruff check src tests && black --check src tests && isort --check-only src tests && mypy --ignore-missing-imports src
```

### 影响与兼容
- 与现有 API/测试兼容，仅新增代码；不改编排逻辑。
- CI 时长影响可忽略（新增用例少量）。

### 风险/回滚
- 低风险；如需回滚：`git revert <merge-commit>`。

### 关联 Issue
- 关联 #44 （分步推进“功能覆盖 + 参数合法性验证”）。
