### PR TITLE
feat(configs,tools): add configs/tests and tools CLI with tests

### DIFF
--- a/configs/deploy/infer_vllm_kubeinfer.yaml
+++ b/configs/deploy/infer_vllm_kubeinfer.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: infer-vllm
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    app: infer-vllm
+  ports:
+  - name: http
+    port: 9000
+    targetPort: 9000
+    nodePort: 30000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infer-vllm
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infer-vllm
+  template:
+    metadata:
+      labels:
+        app: infer-vllm
+    spec:
+      containers:
+      - name: api
+        image: your-registry/vllm:latest
+        ports:
+        - containerPort: 9000
+        env:
+        - name: MODEL
+          value: qwen3-32b
+

--- a/configs/tests/accuracy.yaml
+++ b/configs/tests/accuracy.yaml
@@ -1,0 +1,5 @@
+enabled: true
+task: gpqa
+max_samples: 100
+dataset_split: validation[:100]
+

--- a/configs/tests/functional.yaml
+++ b/configs/tests/functional.yaml
@@ -1,0 +1,12 @@
+enabled: true
+chat:
+  response_format:
+    json_object: true
+    json_schema: true
+  tools: true
+  stream: true
+  sampling:
+    temperature: [0.0, 0.7]
+    top_p: [0.0, 1.0]
+    top_k: [1, 8]
+

--- a/configs/tests/perf.yaml
+++ b/configs/tests/perf.yaml
@@ -1,0 +1,7 @@
+enabled: true
+matrix:
+  concurrency: [1, 2, 4]
+  input_len: [128]
+  output_len: [128]
+runs: 1
+

--- a/tests/tools/test_acs_bench_mock.py
+++ b/tests/tools/test_acs_bench_mock.py
@@ -1,0 +1,29 @@
+"""acs_bench_mock CLI 测试。"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_acs_bench_mock_cli(tmp_path: Path):
+    out = tmp_path / "perf.csv"
+    cmd = [
+        sys.executable,
+        str(Path("tools/acs_bench_mock.py")),
+        "--concurrency",
+        "1,2",
+        "--input-len",
+        "128",
+        "--output-len",
+        "128",
+        "--out",
+        str(out),
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path("src").resolve())
+    subprocess.check_call(cmd, env=env)
+    text = out.read_text(encoding="utf-8")
+    assert "concurrency" in text and "throughput_rps" in text

--- a/tests/tools/test_gen_scenario_yaml.py
+++ b/tests/tools/test_gen_scenario_yaml.py
@@ -1,0 +1,32 @@
+"""gen_scenario_yaml CLI 测试。"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def test_gen_scenario_yaml(tmp_path: Path):
+    out = tmp_path / "sc.yaml"
+    cmd = [
+        sys.executable,
+        str(Path("tools/gen_scenario_yaml.py")),
+        "--id",
+        "local_demo",
+        "--mode",
+        "local",
+        "--model",
+        "Qwen3-32B",
+        "--served-model-name",
+        "qwen3-32b",
+        "--quant",
+        "w8a8",
+        "--out",
+        str(out),
+    ]
+    subprocess.check_call(cmd)
+    data = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert data["id"] == "local_demo" and data["mode"] == "local"

--- a/tests/tools/test_metrics_rename_cli.py
+++ b/tests/tools/test_metrics_rename_cli.py
@@ -1,0 +1,51 @@
+"""metrics_rename CLI 测试。"""
+
+from __future__ import annotations
+
+import csv
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_metrics_rename_csv(tmp_path: Path):
+    src = tmp_path / "in.csv"
+    dst = tmp_path / "out.csv"
+    with src.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=[
+                "concurrency",
+                "input_len",
+                "output_len",
+                "latency_p50_ms",
+                "throughput_rps",
+            ],
+        )
+        w.writeheader()
+        w.writerow(
+            {
+                "concurrency": 1,
+                "input_len": 128,
+                "output_len": 128,
+                "latency_p50_ms": 50.5,
+                "throughput_rps": 12.3,
+            }
+        )
+    cmd = [
+        sys.executable,
+        str(Path("tools/metrics_rename.py")),
+        "--in",
+        str(src),
+        "--out",
+        str(dst),
+        "--fmt",
+        "csv",
+    ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path("src").resolve())
+    subprocess.check_call(cmd, env=env)
+    text = dst.read_text(encoding="utf-8")
+    assert "throughput_requests_per_second" in text
+    assert "latency_p50_milliseconds" in text

--- a/tools/acs_bench_mock.py
+++ b/tools/acs_bench_mock.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""生成性能 CSV（mock）。
+
+基于 `src/vllm_cibench/testsuites/perf.py` 的 `PerfResult` 与 `gen_mock_csv`，
+从命令行参数构造若干行并输出为 CSV 文件，便于离线调试与 CI 演示。
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from vllm_cibench.testsuites.perf import PerfResult, gen_mock_csv
+
+
+def parse_args() -> argparse.Namespace:
+    """解析命令行参数。
+
+    返回值:
+        argparse.Namespace: 包含并发/输入/输出长度与输出路径。
+    副作用:
+        读取命令行。
+    """
+
+    p = argparse.ArgumentParser(description="Generate mock ACS perf CSV")
+    p.add_argument("--concurrency", required=True, help="e.g. 1,2,4")
+    p.add_argument("--input-len", type=int, required=True)
+    p.add_argument("--output-len", type=int, required=True)
+    p.add_argument("--out", type=Path, required=True)
+    return p.parse_args()
+
+
+def main() -> None:
+    """入口：写出 CSV 文件。
+
+    副作用:
+        写入文件系统。
+    """
+
+    ns = parse_args()
+    conc = [int(x) for x in str(ns.concurrency).split(",") if x.strip()]
+    rows: List[PerfResult] = []
+    for c in conc:
+        # 构造一些伪数据：随着并发增加，吞吐上升、p50 略上升
+        rows.append(
+            PerfResult(
+                concurrency=c,
+                input_len=ns.input_len,
+                output_len=ns.output_len,
+                latency_p50_ms=max(1.0, 20.0 + 2.0 * (c - 1)),
+                throughput_rps=max(0.1, 10.0 * c),
+            )
+        )
+    csv_text = gen_mock_csv(rows)
+    ns.out.write_text(csv_text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/gen_scenario_yaml.py
+++ b/tools/gen_scenario_yaml.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""生成场景 YAML 示例。
+
+根据命令行参数生成最小可用的 `configs/scenarios/*.yaml` 内容。
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Generate scenario YAML skeleton")
+    p.add_argument("--id", required=True)
+    p.add_argument("--mode", choices=["local", "k8s-hybrid", "k8s-pd"], required=True)
+    p.add_argument("--model", required=True)
+    p.add_argument("--served-model-name", required=True)
+    p.add_argument("--quant", default="w8a8")
+    p.add_argument("--out", type=Path, required=True)
+    return p.parse_args()
+
+
+def main() -> None:
+    ns = parse_args()
+    content = f"""id: {ns.id}
+mode: {ns.mode}
+model: {ns.model}
+served_model_name: {ns.__dict__['served_model_name']}
+quant: {ns.quant}
+features:
+  guided_decoding: false
+  function_call: false
+  reasoning: false
+base_url: http://127.0.0.1:9000/v1
+startup_timeout_seconds: 1200
+env: {{}}
+args: {{}}
+"""
+    ns.out.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/metrics_rename.py
+++ b/tools/metrics_rename.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""指标名重命名工具。
+
+将 CSV 或 JSON 文件中的通用键名映射到 Prometheus 规范名称，便于统一上报。
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from vllm_cibench.metrics.rename import DEFAULT_MAPPING
+
+
+def parse_args() -> argparse.Namespace:
+    """解析命令行参数。"""
+
+    p = argparse.ArgumentParser(description="Rename metric keys to Prometheus-friendly names")
+    p.add_argument("--in", dest="in_path", type=Path, required=True)
+    p.add_argument("--out", dest="out_path", type=Path, required=True)
+    p.add_argument("--fmt", choices=["csv", "json"], required=True)
+    return p.parse_args()
+
+
+def _rename_dict(d: Dict[str, object]) -> Dict[str, object]:
+    """按 DEFAULT_MAPPING 重命名字典键。"""
+
+    out: Dict[str, object] = {}
+    for k, v in d.items():
+        out[DEFAULT_MAPPING.get(k, k)] = v
+    return out
+
+
+def process_csv(in_path: Path, out_path: Path) -> None:
+    """重命名 CSV 表头并写出新文件。"""
+
+    rows: List[Dict[str, object]] = []
+    with in_path.open("r", encoding="utf-8") as f:
+        r = csv.DictReader(f)
+        for row in r:
+            rows.append(_rename_dict(dict(row)))
+    if not rows:
+        out_path.write_text("", encoding="utf-8")
+        return
+    with out_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        w.writeheader()
+        w.writerows(rows)
+
+
+def process_json(in_path: Path, out_path: Path) -> None:
+    """重命名 JSON（数组或对象）中的键名。"""
+
+    data = json.loads(in_path.read_text(encoding="utf-8") or "{}")
+    if isinstance(data, list):
+        data = [_rename_dict(x) for x in data]
+    elif isinstance(data, dict):
+        data = _rename_dict(data)
+    out_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    ns = parse_args()
+    if ns.fmt == "csv":
+        process_csv(ns.in_path, ns.out_path)
+    else:
+        process_json(ns.in_path, ns.out_path)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
### 目标
- [x] 引入 `configs/tests/*` 与 `tools/*` 脚本（最小可用）并配套单测；保持 CI 绿灯

### 变更内容
- configs/tests/
  - functional.yaml / perf.yaml / accuracy.yaml：示例参数与开关
- configs/deploy/
  - infer_vllm_kubeinfer.yaml：K8s Service + Deployment 示例（文档化用途）
- tools/
  - acs_bench_mock.py：基于 PerfResult/gen_mock_csv 生成 CSV
  - metrics_rename.py：CSV/JSON 指标键名映射到 Prometheus 规范
  - gen_scenario_yaml.py：生成最小场景 YAML
- tests/tools/
  - test_acs_bench_mock.py / test_metrics_rename_cli.py / test_gen_scenario_yaml.py

### 复现实验命令
```bash
python3 -m venv .venv && source .venv/bin/activate
pip install -r requirements-dev.txt
pytest -q -m "not slow"
ruff check src tests && black --check src tests && isort --check-only src tests && mypy --ignore-missing-imports src
```

### 影响与兼容
- 仅新增样例配置与工具脚本；不变更业务逻辑。

### 关联 Issue
- 关联 #41
