### PR TITLE
test(functional,validation): negative streaming/tools/response_format + logprobs bounds

### DIFF
--- a/tests/testsuites/test_functional_chat_n_best_of_stream_invalid.py
+++ b/tests/testsuites/test_functional_chat_n_best_of_stream_invalid.py
@@ -1,0 +1,27 @@
+"""n + best_of + stream 组合的负路径校验。"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+@pytest.mark.functional
+@pytest.mark.validation
+def test_chat_n_gt_best_of_with_stream_invalid(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    err = {"error": {"message": "n cannot be greater than best_of when streaming"}}
+    requests_mock.post(url, json=err, status_code=400)
+    client = OpenAICompatClient(base_url=base)
+    with pytest.raises(Exception):
+        _ = run_basic_chat(
+            client,
+            model="dummy",
+            messages=[{"role": "user", "content": "hi"}],
+            n=2,
+            best_of=1,
+            stream=True,
+        )

--- a/tests/testsuites/test_functional_chat_stream_tools_json_negative.py
+++ b/tests/testsuites/test_functional_chat_stream_tools_json_negative.py
@@ -1,0 +1,62 @@
+"""流式（SSE）+ tools + response_format 的负路径场景。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+@pytest.mark.functional
+@pytest.mark.validation
+def test_stream_with_tools_and_invalid_json_content(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+
+    # 最后一个 content 片段不是合法 JSON
+    content = (
+        'data: {"choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\\"city\\":"}}]}}]}\n\n'
+        'data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\"beijing\\"}"}}]}}]}\n\n'
+        'data: {"choices":[{"index":0,"delta":{"content":"not json"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    requests_mock.post(
+        url,
+        content=content.encode(),
+        headers={"Content-Type": "text/event-stream"},
+        status_code=200,
+    )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    messages = [{"role": "user", "content": "Get weather for Beijing"}]
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=messages,
+        tools=tools,
+        tool_choice="required",
+        response_format={"type": "json_object"},
+        stream=True,
+    )
+
+    # 第三个分块是非 JSON 文本，调用方应自行决定是否解析，这里验证确实原样收到
+    assert out[-1]["choices"][0]["delta"]["content"] == "not json"
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["response_format"]["type"] == "json_object"

--- a/tests/testsuites/test_functional_completions_logprobs_bounds.py
+++ b/tests/testsuites/test_functional_completions_logprobs_bounds.py
@@ -1,0 +1,41 @@
+"""Completions logprobs/top_logprobs 边界与负路径。"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_cibench.testsuites.functional import run_basic_completion
+
+
+@pytest.mark.functional
+@pytest.mark.validation
+def test_logprobs_top_logprobs_zero_invalid(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    err = {"error": {"message": "top_logprobs must be >= 1 when logprobs=True"}}
+    requests_mock.post(url, json=err, status_code=400)
+    with pytest.raises(Exception):
+        _ = run_basic_completion(
+            base_url=base,
+            model="dummy",
+            prompt="hello",
+            logprobs=True,
+            top_logprobs=0,
+        )
+
+
+@pytest.mark.functional
+@pytest.mark.validation
+def test_logprobs_top_logprobs_too_large(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    err = {"error": {"message": "top_logprobs too large"}}
+    requests_mock.post(url, json=err, status_code=400)
+    with pytest.raises(Exception):
+        _ = run_basic_completion(
+            base_url=base,
+            model="dummy",
+            prompt="hello",
+            logprobs=True,
+            top_logprobs=100,
+        )


### PR DESCRIPTION
- Add negative tests: streaming+tools+response_format invalid content; completions logprobs/top_logprobs bounds; chat n>best_of with stream.\n\nLocal: pytest + ruff/black/isort + mypy --strict pass.\n\nRefs: #44