### PR TITLE
docs(todo)+feat(orchestrator): functional suites + functional metrics (daily)

### DIFF
--- a/src/vllm_cibench/orchestrators/run_pipeline.py
+++ b/src/vllm_cibench/orchestrators/run_pipeline.py
@@ -233,6 +233,40 @@ def execute(
             )
             result["functional_report"]["completions"] = report
 
+        # 汇总并在 daily 时推送功能性指标（与性能指标同样受 dry_run 控制）
+        try:
+            fr = result.get("functional_report", {}) or {}
+            totals = {"total": 0, "passed": 0, "failed": 0}
+            for key in ("chat", "completions"):
+                s = (fr.get(key, {}) or {}).get("summary", {}) or {}
+                totals["total"] += int(s.get("total", 0))
+                totals["passed"] += int(s.get("passed", 0))
+                totals["failed"] += int(s.get("failed", 0))
+            if totals["total"] > 0 and not dry_run and run_type == "daily":
+                rate = (totals["passed"] / totals["total"]) if totals["total"] else 0.0
+                func_metrics = {
+                    "ci_functional_total": float(totals["total"]),
+                    "ci_functional_passed": float(totals["passed"]),
+                    "ci_functional_failed": float(totals["failed"]),
+                    "ci_functional_pass_rate": float(rate),
+                }
+                labels = {
+                    "model": scenario.model,
+                    "quant": scenario.quant,
+                    "scenario": scenario.id,
+                }
+                pushed_f = push_metrics(
+                    "vllm_cibench",
+                    func_metrics,
+                    labels=labels,
+                    run_type=run_type,
+                    dry_run=dry_run,
+                )
+                result["pushed"] = bool(result.get("pushed")) or bool(pushed_f)
+        except Exception:
+            # 指标推送异常不影响主流程
+            pass
+
     # Perf (mock-based)
     if plan.get("perf"):
         # 生成少量 mock 数据 -> 解析 -> 重命名 -> 聚合

--- a/tests/testsuites/test_functional_chat_stream_json_schema_missing_required.py
+++ b/tests/testsuites/test_functional_chat_stream_json_schema_missing_required.py
@@ -1,0 +1,56 @@
+"""流式（SSE）+ response_format=json_schema 缺少必需字段的场景。
+
+说明：服务端返回 200 且内容不满足 schema 的情况由上层消费方判定；
+本用例只验证请求体正确传递 response_format，且分块内容缺少字段。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+@pytest.mark.functional
+def test_chat_stream_json_schema_missing_required(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+
+    # SSE：仅输出 {"city":"beijing"}，缺少必需 temp_c 字段
+    content = (
+        'data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}\n\n'
+        'data: {"choices":[{"index":0,"delta":{"content":"{\\"city\\":\\"beijing\\"}"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    requests_mock.post(
+        url,
+        content=content.encode(),
+        headers={"Content-Type": "text/event-stream"},
+        status_code=200,
+    )
+
+    schema = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}, "temp_c": {"type": "number"}},
+        "required": ["city", "temp_c"],
+    }
+
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "weather?"}],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"name": "Weather", "schema": schema},
+        },
+        stream=True,
+    )
+
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["response_format"]["type"] == "json_schema"
+    # 分块缺少 temp_c
+    assert out[-1]["choices"][0]["delta"]["content"] == '{"city":"beijing"}'

--- a/tests/testsuites/test_functional_completions_logprobs_structure.py
+++ b/tests/testsuites/test_functional_completions_logprobs_structure.py
@@ -1,0 +1,46 @@
+"""Completions logprobs 结构与边界（正路径）。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.testsuites.functional import run_basic_completion
+
+
+@pytest.mark.functional
+def test_completions_logprobs_structure(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    payload = {
+        "id": "cmpl-xyz",
+        "object": "text_completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {
+                "index": 0,
+                "text": "X",
+                "logprobs": {
+                    "tokens": ["X"],
+                    "token_logprobs": [-0.1],
+                    "top_logprobs": [[{"token": "X", "logprob": -0.1}]],
+                    "text_offset": [0],
+                },
+            }
+        ],
+    }
+    requests_mock.post(url, json=payload, status_code=200)
+
+    out = run_basic_completion(
+        base_url=base,
+        model="dummy",
+        prompt="Hello",
+        logprobs=True,
+        top_logprobs=1,
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["logprobs"] is True and body["top_logprobs"] == 1
+    lp = out["choices"][0]["logprobs"]
+    assert lp["tokens"][0] == "X" and lp["token_logprobs"][0] == -0.1


### PR DESCRIPTION
- DESIGN_TODO: add M6 functional suites + M7 functional metrics\n- Orchestrator: summarize functional_report and push functional metrics (daily, not in PR/dry-run), labels {model, quant, scenario}.\n\nLocal: pytest + ruff/black/isort + mypy --strict pass.