### PR TITLE
feat(functional-metrics): aggregated + per-case functional metrics (daily)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ export VLLM_CIBENCH_FUNCTIONAL_CONFIG=$(pwd)/configs/tests/functional_example.ya
 python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run
 ```
 
+你也可以使用为不同模型准备的专用配置：
+
+```bash
+# Qwen3-32B 专用覆盖
+export VLLM_CIBENCH_FUNCTIONAL_CONFIG=$(pwd)/configs/tests/functional_qwen3-32b.yaml
+python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run
+
+# DeepSeek-R1 专用覆盖（如有对应场景）
+export VLLM_CIBENCH_FUNCTIONAL_CONFIG=$(pwd)/configs/tests/functional_deepseek-r1.yaml
+python -m vllm_cibench.run run --scenario k8s_pd_deepseek-r1_2p1d_reasoning_w8a8 --run-type pr --dry-run
+```
+
 方式二（修改仓库默认配置）：
 
 ```bash

--- a/configs/tests/functional.yaml
+++ b/configs/tests/functional.yaml
@@ -2,6 +2,10 @@ enabled: true
 # 是否启用批量功能用例（关闭则仅运行 smoke 冒烟）
 suite: false
 
+# 功能性指标推送（仅 daily 且非 dry-run 时生效）
+functional_metrics:
+  per_case: false
+
 # 最小示例用例（如需启用，请将 suite 置为 true）
 cases:
   - id: chat_hello

--- a/configs/tests/functional_deepseek-r1.yaml
+++ b/configs/tests/functional_deepseek-r1.yaml
@@ -1,0 +1,35 @@
+enabled: true
+suite: true
+
+cases:
+  - id: chat_reasoning_basic
+    type: chat
+    messages:
+      - role: user
+        content: "Explain why 2+2=4 in one sentence."
+    params:
+      reasoning: true
+      temperature: 0
+
+matrices:
+  chat:
+    - id_prefix: ds_bounds
+      messages:
+        - role: user
+          content: "Give a short reasoning about gravity."
+      params_grid:
+        temperature: [0.0, 1.0]
+        top_p: [0.0, 1.0]
+      expect_error: false
+
+negative:
+  chat:
+    - id_prefix: ds_invalid
+      messages:
+        - role: user
+          content: "hi"
+      params_list:
+        - {top_k: -1}
+        - {temperature: -0.1}
+      expect_error: true
+

--- a/configs/tests/functional_example.yaml
+++ b/configs/tests/functional_example.yaml
@@ -5,6 +5,10 @@
 enabled: true
 suite: true
 
+# 功能性指标推送（仅 daily 且非 dry-run 时生效）
+functional_metrics:
+  per_case: true
+
 cases:
   # Basic chat
   - id: chat_basic
@@ -72,4 +76,3 @@ negative:
         - {logprobs: true, top_logprobs: 0}
         - {logprobs: true, top_logprobs: 100}
       expect_error: true
-

--- a/configs/tests/functional_qwen3-32b.yaml
+++ b/configs/tests/functional_qwen3-32b.yaml
@@ -1,0 +1,107 @@
+enabled: true
+suite: true
+
+cases:
+  - id: chat_basic
+    type: chat
+    messages:
+      - role: user
+        content: "Say hello in one word."
+    params:
+      temperature: 0
+
+  - id: chat_json_object
+    type: chat
+    messages:
+      - role: user
+        content: "Return a JSON object with key 'ok'=true."
+    params:
+      response_format: {type: json_object}
+
+  - id: chat_tools_named_required
+    type: chat
+    messages:
+      - role: user
+        content: "Get weather for Beijing"
+    params:
+      tools:
+        - type: function
+          function:
+            name: get_weather
+            description: Get weather by city
+            parameters:
+              type: object
+              properties: {city: {type: string}}
+              required: [city]
+      tool_choice: {type: function, function: {name: get_weather}}
+
+  - id: chat_stream_basic
+    type: chat
+    messages:
+      - role: user
+        content: "Greet me."
+    params:
+      stream: true
+      temperature: 0
+
+  - id: comp_basic
+    type: completions
+    prompt: "Hello"
+    params:
+      max_tokens: 8
+
+matrices:
+  chat:
+    - id_prefix: chat_bounds
+      messages:
+        - role: user
+          content: "Summarize: vLLM is great."
+      params_grid:
+        temperature: [0.0, 1.0]
+        top_p: [0.0, 1.0]
+        top_k: [1, 8]
+      expect_error: false
+  completions:
+    - id_prefix: comp_bounds
+      prompt: "Say X"
+      params_grid:
+        logprobs: [false, true]
+        top_logprobs: [1, 3]
+      expect_error: false
+
+negative:
+  chat:
+    - id_prefix: chat_invalid_top_p
+      messages:
+        - role: user
+          content: "hi"
+      params_list:
+        - {top_p: 1.5}
+      expect_error: true
+    - id_prefix: chat_n_gt_best_of_stream
+      messages:
+        - role: user
+          content: "hi"
+      params_list:
+        - {n: 2, best_of: 1, stream: true}
+      expect_error: true
+    - id_prefix: chat_negative_temperature
+      messages:
+        - role: user
+          content: "hi"
+      params_list:
+        - {temperature: -0.1}
+      expect_error: true
+  completions:
+    - id_prefix: comp_logprobs_bounds
+      prompt: "hello"
+      params_list:
+        - {logprobs: true, top_logprobs: 0}
+        - {logprobs: true, top_logprobs: 100}
+      expect_error: true
+    - id_prefix: comp_negative_max_tokens
+      prompt: "hello"
+      params_list:
+        - {max_tokens: -1}
+      expect_error: true
+


### PR DESCRIPTION
- Orchestrator: summarize functional_report and push aggregated metrics.\n- Optional per-case metrics controlled by configs/tests/functional.yaml: functional_metrics.per_case.\n- Only pushed on daily and non-dry-run, labels {model, quant, scenario[, case, kind]}.\n\nLocal: pytest + ruff/black/isort + mypy --strict pass.