### PR TITLE
feat(functional): capability-aware skipping and extend vLLM coverage

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,9 +24,10 @@ jobs:
           python-version: '3.11'
       - run: pip install -r requirements.txt
       - run: pip install -r requirements-dev.txt
-      - name: Run daily matrix
+      - name: Run daily matrix (with functional suite)
         env:
           PROM_PUSHGATEWAY_URL: ${{ secrets.PROM_PUSHGATEWAY_URL }}
+          VLLM_CIBENCH_FUNCTIONAL_CONFIG: ${{ github.workspace }}/configs/tests/functional_example.yaml
         run: |
           ARGS=""
           if [ "${{ inputs.dry-run }}" = "true" ]; then

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ python -m vllm_cibench.run run --scenario <sid> --run-type pr --dry-run
 
 配置格式说明可参考 `configs/tests/functional_example.yaml` 中的 cases/matrices/negative 示例。
 
+### 独立运行功能性套件（不走编排）
+
+若只需对接一个服务端点，可直接运行独立 CLI：
+
+```bash
+python -m vllm_cibench.run run-functional \
+  --base-url http://127.0.0.1:9000/v1 \
+  --model qwen3-32b \
+  --config ./configs/tests/functional_qwen3-32b.yaml
+```
+
+输出仅包含功能性报告 `{chat, completions}`，不包含性能/推送等编排行为。
+
 ## 指标推送
 
 性能阶段仅在 `run-type=daily` 且设置 `PROM_PUSHGATEWAY_URL` 时推送指标：

--- a/configs/tests/functional_deepseek-r1.yaml
+++ b/configs/tests/functional_deepseek-r1.yaml
@@ -1,6 +1,9 @@
 enabled: true
 suite: true
 
+functional_metrics:
+  per_case: true
+
 cases:
   - id: chat_reasoning_basic
     type: chat
@@ -21,6 +24,14 @@ matrices:
         temperature: [0.0, 1.0]
         top_p: [0.0, 1.0]
       expect_error: false
+    - id_prefix: ds_bounds_stop
+      messages:
+        - role: user
+          content: "Explain briefly, then stop at token 'END'."
+      params_grid:
+        stop: [["END"]]
+        temperature: [0.0, 1.0]
+      expect_error: false
 
 negative:
   chat:
@@ -32,4 +43,10 @@ negative:
         - {top_k: -1}
         - {temperature: -0.1}
       expect_error: true
-
+    - id_prefix: ds_invalid_json_schema
+      messages:
+        - role: user
+          content: "Return a JSON with key 'ok' true."
+      params_list:
+        - {response_format: {type: json_object}, stream: true, n: 2, best_of: 1}
+      expect_error: true

--- a/configs/tests/functional_example.yaml
+++ b/configs/tests/functional_example.yaml
@@ -9,6 +9,20 @@ suite: true
 functional_metrics:
   per_case: true
 
+# 可选：显式声明服务能力（用于按能力跳过用例）；也可通过
+# 环境变量 `VLLM_CIBENCH_CAPABILITIES` 传入，或由场景 features 派生。
+capabilities:
+  - chat.tools
+  - chat.tool_choice
+  - chat.tool_choice.by_name
+  - chat.tool_calls.parallel
+  - chat.response_format.json_object
+  - chat.response_format.json_schema
+  - chat.reasoning
+  - chat.logprobs
+  - completions.suffix
+  - completions.best_of
+
 cases:
   # Basic chat
   - id: chat_basic

--- a/configs/tests/functional_qwen3-32b.yaml
+++ b/configs/tests/functional_qwen3-32b.yaml
@@ -1,6 +1,9 @@
 enabled: true
 suite: true
 
+functional_metrics:
+  per_case: true
+
 cases:
   - id: chat_basic
     type: chat
@@ -17,6 +20,33 @@ cases:
         content: "Return a JSON object with key 'ok'=true."
     params:
       response_format: {type: json_object}
+
+  - id: chat_json_schema_with_tools
+    type: chat
+    messages:
+      - role: user
+        content: "Get weather for Beijing and return JSON with keys city,temp_c."
+    params:
+      tools:
+        - type: function
+          function:
+            name: get_weather
+            description: Get weather by city
+            parameters:
+              type: object
+              properties: {city: {type: string}}
+              required: [city]
+      tool_choice: required
+      response_format:
+        type: json_schema
+        json_schema:
+          name: Weather
+          schema:
+            type: object
+            properties:
+              city: {type: string}
+              temp_c: {type: number}
+            required: [city, temp_c]
 
   - id: chat_tools_named_required
     type: chat
@@ -44,6 +74,25 @@ cases:
       stream: true
       temperature: 0
 
+  - id: chat_multiturn_stream_tools
+    type: chat
+    messages:
+      - role: system
+        content: "You are helpful."
+      - role: user
+        content: "What's the weather in Beijing?"
+    params:
+      tools:
+        - type: function
+          function:
+            name: get_weather
+            parameters:
+              type: object
+              properties: {city: {type: string}}
+              required: [city]
+      tool_choice: required
+      stream: true
+
   - id: comp_basic
     type: completions
     prompt: "Hello"
@@ -60,6 +109,14 @@ matrices:
         temperature: [0.0, 1.0]
         top_p: [0.0, 1.0]
         top_k: [1, 8]
+      expect_error: false
+    - id_prefix: chat_bounds_stop
+      messages:
+        - role: user
+          content: "Say A B C"
+      params_grid:
+        stop: [["B"]]
+        max_tokens: [4, 8]
       expect_error: false
   completions:
     - id_prefix: comp_bounds
@@ -92,6 +149,13 @@ negative:
       params_list:
         - {temperature: -0.1}
       expect_error: true
+    - id_prefix: chat_invalid_stop_token_ids
+      messages:
+        - role: user
+          content: "hi"
+      params_list:
+        - {stop_token_ids: ["bad"]}
+      expect_error: true
   completions:
     - id_prefix: comp_logprobs_bounds
       prompt: "hello"
@@ -104,4 +168,8 @@ negative:
       params_list:
         - {max_tokens: -1}
       expect_error: true
-
+    - id_prefix: comp_invalid_echo_type
+      prompt: "hello"
+      params_list:
+        - {echo: "true"}
+      expect_error: true

--- a/scripts/collect_and_push.sh
+++ b/scripts/collect_and_push.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# 从性能 CSV 聚合指标并推送至 Prometheus Pushgateway（与项目条件一致）。
+#
+# 功能：
+# - 读取 CSV（字段需包含 throughput_rps/latency_p50_ms 等），
+# - 聚合为平均值，构造 ci_perf_* 指标，
+# - 调用项目内 Python API（vllm_cibench.metrics.pushgateway）执行推送。
+#
+# 示例：
+#   scripts/collect_and_push.sh \
+#     --csv ./artifacts/perf.csv \
+#     --run-type daily \
+#     --label model=Qwen3-32B --label quant=w8a8 --label scenario=local_single \
+#     --gateway-url http://pushgw:9091
+#
+# 注意：
+# - 仅当 run-type=daily 且（未指定 --gateway-url 时）环境变量 PROM_PUSHGATEWAY_URL 存在时会推送；
+# - 在 Fork 或非主仓库时，Python API 会自动跳过推送。
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+用法：collect_and_push.sh [选项]
+
+必选：
+  -c, --csv PATH           性能 CSV 文件路径
+
+可选：
+  -r, --run-type TYPE      运行类型 pr/daily（默认 daily）
+      --dry-run            仅打印不推送
+  -l, --label K=V          追加标签（可多次），例如 model=Qwen3-32B
+      --gateway-url URL    覆盖 PROM_PUSHGATEWAY_URL 环境变量
+  -h, --help               显示帮助
+USAGE
+}
+
+CSV_PATH=""
+RUN_TYPE="daily"
+DRY_RUN=0
+GATEWAY_URL=""
+declare -a LABELS
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -c|--csv)
+      CSV_PATH="$2"; shift 2 ;;
+    -r|--run-type)
+      RUN_TYPE="$2"; shift 2 ;;
+    --dry-run)
+      DRY_RUN=1; shift 1 ;;
+    -l|--label)
+      LABELS+=("$2"); shift 2 ;;
+    --gateway-url)
+      GATEWAY_URL="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "未知参数：$1" >&2
+      usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "$CSV_PATH" ]]; then
+  echo "错误：必须指定 --csv 路径" >&2
+  usage
+  exit 2
+fi
+if [[ ! -f "$CSV_PATH" ]]; then
+  echo "错误：找不到 CSV 文件：$CSV_PATH" >&2
+  exit 1
+fi
+
+# 将标签数组转换为 Python 可消费的 dict 形式
+PY_LABELS="{}"
+if [[ ${#LABELS[@]} -gt 0 ]]; then
+  # 简单构造：分割 key=value；忽略不合法项
+  PY_LABELS="{"
+  first=1
+  for kv in "${LABELS[@]}"; do
+    if [[ "$kv" == *"="* ]]; then
+      key=${kv%%=*}
+      val=${kv#*=}
+      if [[ $first -eq 1 ]]; then
+        PY_LABELS+="'${key//\'/\'\'}':'${val//\'/\'\'}'"
+        first=0
+      else
+        PY_LABELS+=" ,'${key//\'/\'\'}':'${val//\'/\'\'}'"
+      fi
+    fi
+  done
+  PY_LABELS+="}"
+fi
+
+echo "读取 CSV 并聚合指标：$CSV_PATH"
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "[DRY-RUN] 将跳过推送，仅打印聚合指标"
+fi
+
+# 运行内联 Python：解析 CSV -> 聚合 -> 可选推送
+python - "$CSV_PATH" "$RUN_TYPE" "$DRY_RUN" "$GATEWAY_URL" "$PY_LABELS" <<'PY'
+import io
+import json
+import os
+import sys
+from typing import Dict, Any
+
+csv_path = sys.argv[1]
+run_type = sys.argv[2]
+dry_run = bool(int(sys.argv[3]))
+gateway_url = sys.argv[4] or None
+labels_expr = sys.argv[5]
+try:
+    labels: Dict[str, str] = json.loads(labels_expr.replace("'", '"')) if labels_expr else {}
+except Exception:
+    labels = {}
+
+# 允许从任意工作目录运行：将仓库根加入 sys.path（脚本位于 scripts/）
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+from vllm_cibench.testsuites.perf import parse_perf_csv  # noqa: E402
+from vllm_cibench.metrics.pushgateway import (  # noqa: E402
+    metrics_from_perf_records,
+    push_metrics,
+)
+
+text = open(csv_path, "r", encoding="utf-8").read()
+records = parse_perf_csv(text)
+agg = metrics_from_perf_records(records)
+
+print("聚合结果：", json.dumps(agg, ensure_ascii=False))
+
+ok = push_metrics(
+    job="vllm_cibench",
+    metrics=agg,
+    labels=labels,
+    gateway_url=gateway_url,
+    run_type=run_type,
+    dry_run=dry_run,
+)
+print("推送状态：", ok)
+PY
+
+exit 0
+

--- a/scripts/deploy_k8s.sh
+++ b/scripts/deploy_k8s.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# 轻量级 K8s 部署脚本
+#
+# 用途：对给定的 K8s YAML 执行 kubectl apply，并给出简单的探活提示。
+#
+# 使用示例：
+#   scripts/deploy_k8s.sh -f configs/deploy/infer_vllm_kubeinfer.yaml
+#   scripts/deploy_k8s.sh --file ./my_deploy.yaml --namespace infer --wait 60
+#
+# 退出码：
+#   0 = 成功提交给 K8s；非 0 = 发生错误（例如缺少 kubectl/YAML 不存在）。
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+用法：deploy_k8s.sh [选项]
+
+选项：
+  -f, --file PATH          部署的 YAML 文件（默认：configs/deploy/infer_vllm_kubeinfer.yaml）
+  -n, --namespace NS       目标命名空间（可选）
+  -w, --wait SECONDS       部署后等待的秒数，仅做提示性等待（默认 0）
+  -h, --help               显示本帮助
+
+说明：
+  本脚本仅封装最小化的 kubectl apply 操作，并不会做复杂的就绪性判断。
+  若需探活或更精细的等待逻辑，请结合项目的编排 CLI（run/run-matrix）或在 CI 中使用 wait 步骤。
+USAGE
+}
+
+YAML_PATH="configs/deploy/infer_vllm_kubeinfer.yaml"
+NAMESPACE=""
+WAIT_SECONDS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -f|--file)
+      YAML_PATH="$2"; shift 2 ;;
+    -n|--namespace)
+      NAMESPACE="$2"; shift 2 ;;
+    -w|--wait)
+      WAIT_SECONDS="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "未知参数：$1" >&2
+      usage; exit 2 ;;
+  esac
+done
+
+# 校验 kubectl
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "错误：未找到 kubectl，请先安装并配置 KUBECONFIG。" >&2
+  exit 1
+fi
+
+# 校验文件
+if [[ ! -f "$YAML_PATH" ]]; then
+  echo "错误：找不到 YAML 文件：$YAML_PATH" >&2
+  exit 1
+fi
+
+set -x
+if [[ -n "$NAMESPACE" ]]; then
+  kubectl apply -n "$NAMESPACE" -f "$YAML_PATH"
+else
+  kubectl apply -f "$YAML_PATH"
+fi
+set +x
+
+if [[ "$WAIT_SECONDS" -gt 0 ]]; then
+  echo "已提交资源至集群，等待 ${WAIT_SECONDS}s 以便资源创建……"
+  sleep "$WAIT_SECONDS"
+fi
+
+cat <<EOF
+已执行 kubectl apply：$YAML_PATH
+下一步建议：
+- 使用 'kubectl get pods -A | grep -i vllm' 查看 Pod 状态
+- 暴露端口/查看 Service：'kubectl get svc -A | grep -i vllm'
+- 如需手动探活，可端口转发后访问：curl http://127.0.0.1:9000/v1/models
+EOF
+
+exit 0
+

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -10,9 +10,7 @@
 """
 
 from __future__ import annotations
-
 import json as _json
-import json
 from pathlib import Path
 from pathlib import Path as _Path
 from typing import Optional
@@ -88,7 +86,7 @@ def plan(
 
     plan_obj = resolve_plan(matrix, scenario, run_type)
     typer.echo(
-        json.dumps(
+        _json.dumps(
             {"scenario": scenario, "run_type": run_type, "plan": plan_obj},
             ensure_ascii=False,
         )
@@ -144,7 +142,7 @@ def run(
         timeout_s=timeout,
         dry_run=dry_run,
     )
-    typer.echo(json.dumps(res, ensure_ascii=False))
+    typer.echo(_json.dumps(res, ensure_ascii=False))
 
 
 @app.command("run-matrix")
@@ -173,7 +171,7 @@ def run_matrix(
     res = run_matrix_mod.execute_matrix(
         run_type=run_type, root=root, dry_run=dry_run, timeout_s=timeout
     )
-    typer.echo(json.dumps(res, ensure_ascii=False))
+    typer.echo(_json.dumps(res, ensure_ascii=False))
 
 
 if __name__ == "__main__":

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -10,6 +10,7 @@
 """
 
 from __future__ import annotations
+
 import json as _json
 from pathlib import Path
 from pathlib import Path as _Path

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -1,3 +1,4 @@
+# isort: skip_file
 """命令行入口（规划/Plan）。
 
 提供最小的 `plan` 子命令：

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -11,13 +11,12 @@
 
 from __future__ import annotations
 
-import json
+import json as _json
 from pathlib import Path
+from pathlib import Path as _Path
 from typing import Optional
 
 import typer
-import json as _json
-from pathlib import Path as _Path
 import yaml as _yaml
 
 from .config import ScenarioRegistry, load_matrix, resolve_plan

--- a/src/vllm_cibench/run.py
+++ b/src/vllm_cibench/run.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import json as _json
+import json
 from pathlib import Path
 from pathlib import Path as _Path
 from typing import Optional

--- a/tests/testsuites/test_chat_other_boundaries.py
+++ b/tests/testsuites/test_chat_other_boundaries.py
@@ -1,0 +1,62 @@
+"""Chat 端其他边界：max_tokens、stop 字符串、top_k=0。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+def _payload():
+    return {
+        "id": "chatcmpl-xyz",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": "ok"}}
+        ],
+    }
+
+
+@pytest.mark.functional
+def test_chat_max_tokens_positive(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    requests_mock.post(url, json=_payload(), status_code=200)
+    client = OpenAICompatClient(base_url=base)
+    _ = run_basic_chat(
+        client, model="dummy", messages=[{"role": "user", "content": "x"}], max_tokens=4
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["max_tokens"] == 4
+
+
+@pytest.mark.functional
+def test_chat_stop_string(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    requests_mock.post(url, json=_payload(), status_code=200)
+    client = OpenAICompatClient(base_url=base)
+    _ = run_basic_chat(
+        client, model="dummy", messages=[{"role": "user", "content": "x"}], stop="END"
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["stop"] == "END"
+
+
+@pytest.mark.functional
+def test_chat_top_k_zero(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    requests_mock.post(url, json=_payload(), status_code=200)
+    client = OpenAICompatClient(base_url=base)
+    _ = run_basic_chat(
+        client, model="dummy", messages=[{"role": "user", "content": "x"}], top_k=0
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["top_k"] == 0
+

--- a/tests/testsuites/test_completions_suffix_best_of.py
+++ b/tests/testsuites/test_completions_suffix_best_of.py
@@ -1,0 +1,41 @@
+"""Completions 的 suffix 与 best_of 正路径覆盖。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.testsuites.functional import run_basic_completion
+
+
+@pytest.mark.functional
+def test_completions_suffix_and_best_of_positive(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/completions"
+    payload = {
+        "id": "cmpl-xyz",
+        "object": "text_completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {"index": 0, "text": "A"},
+            {"index": 1, "text": "B"},
+        ],
+    }
+    requests_mock.post(url, json=payload, status_code=200)
+
+    out = run_basic_completion(
+        base_url=base,
+        model="dummy",
+        prompt="Hello",
+        suffix=" end",
+        n=2,
+        best_of=3,
+        max_tokens=8,
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["suffix"] == " end"
+    assert body["n"] == 2 and body["best_of"] == 3
+    assert len(out["choices"]) == 2
+

--- a/tests/testsuites/test_functional_chat_logprobs.py
+++ b/tests/testsuites/test_functional_chat_logprobs.py
@@ -1,0 +1,39 @@
+"""Chat 端点 logprobs/top_logprobs 功能覆盖。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+@pytest.mark.functional
+def test_chat_logprobs_and_top_logprobs(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    payload = {
+        "id": "chatcmpl-xyz",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": "ok"}}
+        ],
+    }
+    requests_mock.post(url, json=payload, status_code=200)
+
+    client = OpenAICompatClient(base_url=base)
+    _ = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "hi"}],
+        logprobs=True,
+        top_logprobs=2,
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["logprobs"] is True
+    assert body["top_logprobs"] == 2
+

--- a/tests/testsuites/test_functional_function_call_details.py
+++ b/tests/testsuites/test_functional_function_call_details.py
@@ -1,0 +1,168 @@
+"""Function Call 细化覆盖：按名选择、多调用、流式+tools 正路径。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+@pytest.mark.functional
+def test_tool_choice_by_name(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    payload = {
+        "id": "chatcmpl-xyz",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "get_weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    requests_mock.post(url, json=payload, status_code=200)
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["tool_choice"]["type"] == "function"
+    assert body["tool_choice"]["function"]["name"] == "get_weather"
+    name = out["choices"][0]["message"]["tool_calls"][0]["function"]["name"]
+    assert name == "get_weather"
+
+
+@pytest.mark.functional
+def test_parallel_tool_calls(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    payload = {
+        "id": "chatcmpl-xyz",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "f1", "arguments": "{}"},
+                        },
+                        {
+                            "id": "call_2",
+                            "type": "function",
+                            "function": {"name": "f2", "arguments": "{}"},
+                        },
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    requests_mock.post(url, json=payload, status_code=200)
+
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "f1",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "f2",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ],
+        tool_choice="auto",
+    )
+    calls = out["choices"][0]["message"]["tool_calls"]
+    assert len(calls) == 2 and {c["function"]["name"] for c in calls} == {"f1", "f2"}
+
+
+@pytest.mark.functional
+def test_stream_with_tools_positive(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    # 简化：流式仅返回两段内容与 [DONE]，不强求 tool_calls 的 SSE 细节
+    content = (
+        'data: {"choices":[{"index":0,"delta":{"role":"assistant"}}]}\n\n'
+        'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    requests_mock.post(
+        url,
+        content=content.encode(),
+        headers={"Content-Type": "text/event-stream"},
+        status_code=200,
+    )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
+
+    client = OpenAICompatClient(base_url=base)
+    out = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=tools,
+        tool_choice="auto",
+        stream=True,
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["stream"] is True and body["tools"][0]["function"]["name"] == "get_weather"
+    assert isinstance(out, list) and len(out) == 2
+

--- a/tests/testsuites/test_guided_stream_positive.py
+++ b/tests/testsuites/test_guided_stream_positive.py
@@ -1,0 +1,43 @@
+"""Guided Decoding（response_format）+ 流式 正路径覆盖。"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vllm_cibench.clients.openai_client import OpenAICompatClient
+from vllm_cibench.testsuites.functional import run_basic_chat
+
+
+@pytest.mark.functional
+def test_chat_stream_json_object_positive(requests_mock):
+    base = "http://example.com/v1"
+    url = base + "/chat/completions"
+    # 分块可拼接为完整 JSON
+    content = (
+        'data: {"choices":[{"index":0,"delta":{"content":"{\\"city\\":"}}]}\n\n'
+        'data: {"choices":[{"index":0,"delta":{"content":"\\"beijing\\"}"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    requests_mock.post(
+        url,
+        content=content.encode(),
+        headers={"Content-Type": "text/event-stream"},
+        status_code=200,
+    )
+
+    client = OpenAICompatClient(base_url=base)
+    chunks = run_basic_chat(
+        client,
+        model="dummy",
+        messages=[{"role": "user", "content": "weather"}],
+        response_format={"type": "json_object"},
+        stream=True,
+    )
+    body = json.loads(requests_mock.request_history[0].text)
+    assert body["response_format"]["type"] == "json_object"
+    text = "".join([c["choices"][0]["delta"].get("content", "") for c in chunks])
+    obj = json.loads(text)
+    assert obj["city"] == "beijing"
+

--- a/tests/testsuites/test_reasoning_negative_missing.py
+++ b/tests/testsuites/test_reasoning_negative_missing.py
@@ -1,0 +1,23 @@
+"""Reasoning 负路径：缺少 reasoning_content 字段。"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_cibench.testsuites.functional import get_reasoning
+
+
+@pytest.mark.functional
+def test_reasoning_missing_key_raises():
+    out = {
+        "id": "chatcmpl-xyz",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "dummy",
+        "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": "ok"}},
+        ],
+    }
+    with pytest.raises(KeyError):
+        _ = get_reasoning(out)
+

--- a/tests/testsuites/test_suite_capabilities_skip.py
+++ b/tests/testsuites/test_suite_capabilities_skip.py
@@ -1,0 +1,33 @@
+"""能力探测跳过：对未支持能力的用例标记为 skipped。"""
+
+from __future__ import annotations
+
+import pytest
+
+from vllm_cibench.testsuites.functional import ChatCase, run_chat_suite
+
+
+@pytest.mark.functional
+def test_chat_suite_skips_unsupported_capability(monkeypatch):
+    # 构造要求 chat.logprobs 能力的用例，但不提供该能力
+    case = ChatCase(
+        id="need_chat_logprobs",
+        messages=[{"role": "user", "content": "hi"}],
+        params={"logprobs": True, "top_logprobs": 1},
+        required_capabilities=["chat.logprobs"],
+        skip_if_unsupported=True,
+    )
+
+    # 不应发生任何网络请求，因此无需 requests_mock；直接运行套件
+    report = run_chat_suite(
+        base_url="http://example.com/v1",
+        model="dummy",
+        cases=[case],
+        capabilities=[],  # 缺少 chat.logprobs
+    )
+    assert report["summary"]["total"] == 1
+    assert report["summary"]["skipped"] == 1
+    assert report["summary"]["passed"] == 0
+    assert report["summary"]["failed"] == 0
+    assert report["results"][0]["skipped"] is True
+


### PR DESCRIPTION
This PR enhances functional coverage with capability-aware skipping and adds missing vLLM-facing features and boundaries.\n\nWhat\'s included:\n- Capability-aware skipping in functional suites (required_capabilities, skip_if_unsupported)\n- Orchestrator wires capabilities from env (VLLM_CIBENCH_CAPABILITIES), functional config (capabilities: []), and scenario features -> suites\n- New functional coverage: chat logprobs, function call (by-name/parallel/stream), guided+stream positive, completions suffix+best_of, chat boundaries (max_tokens/stop string/top_k=0), reasoning negative\n- Functional example config includes capabilities; README updated\n- Scripts: deploy_k8s.sh & collect_and_push.sh\n\nScenarios & commands to reproduce:\n- Plan: python -m vllm_cibench.run plan --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr\n- Run (dry, functional suite off by default): python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run\n- Enable suite with example config: export VLLM_CIBENCH_FUNCTIONAL_CONFIG=/Users/dongguyin/Documents/code/vllm_cibench/configs/tests/functional_example.yaml; python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run\n- Capability override (optional): export VLLM_CIBENCH_CAPABILITIES="chat.tools,chat.response_format.json_schema,completions.suffix"\n\nNotes:\n- Functional metrics push still daily-only & respects --dry-run; added skipped count in reports.\n- Unit/system tests: pytest -q -m "not slow"\n\n