### PR TITLE
feat(perf): orchestrator real-mode perf (behind switch)

### DIFF
--- a/src/vllm_cibench/orchestrators/run_pipeline.py
+++ b/src/vllm_cibench/orchestrators/run_pipeline.py
@@ -397,7 +397,9 @@ def execute(
     # Perf（mock 或 real）
     if plan.get("perf"):
         mode_env = os.environ.get("VLLM_CIBENCH_PERF_MODE", "").strip().lower()
-        real_mode = mode_env == "real" or bool((scenario.raw.get("perf", {}) or {}).get("mode") == "real")
+        real_mode = mode_env == "real" or bool(
+            (scenario.raw.get("perf", {}) or {}).get("mode") == "real"
+        )
         if real_mode:
             # 真实执行：读取 profile（默认按 run_type 选择 pr/daily），可被环境变量覆盖
             prof_path_env = os.environ.get("VLLM_CIBENCH_PERF_PROFILE")
@@ -415,7 +417,9 @@ def execute(
                 concurrency=list(data.get("concurrency", []) or []),
                 input_length=list(data.get("input_length", []) or []),
                 output_length=list(data.get("output_length", []) or []),
-                num_requests_per_concurrency=int(data.get("num_requests_per_concurrency", 8)),
+                num_requests_per_concurrency=int(
+                    data.get("num_requests_per_concurrency", 8)
+                ),
                 warmup=int(data.get("warmup", 1)),
                 epochs=int(data.get("epochs", 1)),
                 temperature=float(data.get("temperature", 0.0)),
@@ -437,7 +441,11 @@ def execute(
         parsed = parse_perf_csv(csv_text)
         renamed = [rename_record_keys(r, DEFAULT_MAPPING) for r in parsed]
         agg = metrics_from_perf_records(parsed)
-        result["perf_metrics"] = {**agg, "records": renamed, "mode": ("real" if real_mode else "mock")}
+        result["perf_metrics"] = {
+            **agg,
+            "records": renamed,
+            "mode": ("real" if real_mode else "mock"),
+        }
 
         # Push（仅 daily）
         labels = {

--- a/tests/orchestrators/test_run_pipeline_perf_real.py
+++ b/tests/orchestrators/test_run_pipeline_perf_real.py
@@ -10,10 +10,20 @@ import vllm_cibench.orchestrators.run_pipeline as rp
 
 
 @pytest.mark.perf
-def test_execute_perf_real_mode_monkeypatched(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_execute_perf_real_mode_monkeypatched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     # 避免真实探活
-    monkeypatch.setattr(rp, "_discover_and_wait", lambda base, s, timeout_s=60.0: "http://127.0.0.1:9000/v1")
-    monkeypatch.setattr(rp, "run_smoke_suite", lambda base_url, model: {"choices": [{"message": {"content": "ok"}}]})
+    monkeypatch.setattr(
+        rp,
+        "_discover_and_wait",
+        lambda base, s, timeout_s=60.0: "http://127.0.0.1:9000/v1",
+    )
+    monkeypatch.setattr(
+        rp,
+        "run_smoke_suite",
+        lambda base_url, model: {"choices": [{"message": {"content": "ok"}}]},
+    )
     monkeypatch.setattr(rp, "push_metrics", lambda *a, **kw: False)
     # 伪造 run_profile_to_csv 返回的 CSV 文本
     csv_text = "\n".join(


### PR DESCRIPTION
Wire the minimal real perf executor into orchestrator behind a guarded switch.\n\n- Enable with env VLLM_CIBENCH_PERF_MODE=real or scenario.perf.mode=real\n- Profile defaults to configs/tests/perf/profiles/{pr|daily}.yaml; override with env VLLM_CIBENCH_PERF_PROFILE\n- Default remains mock; no change to CI unless explicitly enabled\n- Tests added; ruff/black/isort/mypy stric, pytest all pass locally\n