### PR TITLE
feat(deploy/k8s): optional cleanup hook + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --r
 
   注意：仅 `run-type=daily` 且已设置 `PROM_PUSHGATEWAY_URL`（或传入 `--gateway-url`）时会推送；在 fork 或非主仓库会自动跳过推送。
 
+### K8s 场景清理（可选）
+
+- 在编排结束后，如果提供了删除 YAML，将尝试 `kubectl delete -f` 清理资源：
+
+  - 场景内配置：`raw.k8s_delete_yaml: ./configs/deploy/infer_vllm_kubeinfer.yaml`
+  - 或环境变量：`export VLLM_CIBENCH_K8S_DELETE_YAML=$(pwd)/configs/deploy/infer_vllm_kubeinfer.yaml`
+
+- 命名空间取自场景 `raw.k8s.namespace`，删除失败会被忽略（不影响主流程）。
+
 ## 开发与调试
 
 ```bash

--- a/src/vllm_cibench/deploy/k8s/cleanup.py
+++ b/src/vllm_cibench/deploy/k8s/cleanup.py
@@ -1,0 +1,37 @@
+"""K8s 资源清理工具。
+
+提供基于 `kubectl delete -f` 的最小化清理能力，便于在编排结束后
+按场景释放已部署的资源（可选行为）。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+
+def delete_resources(yaml_path: Path, namespace: Optional[str] = None) -> bool:
+    """删除指定 YAML 中定义的 K8s 资源。
+
+    参数:
+        yaml_path: 资源定义的 YAML 文件路径。
+        namespace: 可选命名空间；不提供则遵循 YAML 中配置。
+
+    返回值:
+        bool: True 表示删除命令已执行（不保证资源实际存在）；失败返回 False。
+
+    副作用:
+        调用 `kubectl delete`；若 `kubectl` 不存在或删除失败，将捕获异常并返回 False。
+    """
+
+    try:
+        if not yaml_path.exists():
+            return False
+        cmd = ["kubectl", "delete", "-f", str(yaml_path)]
+        if namespace:
+            cmd = ["kubectl", "delete", "-n", str(namespace), "-f", str(yaml_path)]
+        subprocess.run(cmd, check=False)
+        return True
+    except Exception:
+        return False

--- a/tests/deploy/test_k8s_cleanup.py
+++ b/tests/deploy/test_k8s_cleanup.py
@@ -1,0 +1,83 @@
+"""K8s 清理钩子（编排结束后的可选清理）测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import vllm_cibench.orchestrators.run_pipeline as rp
+from vllm_cibench.config import Scenario
+
+
+class _Calls:
+    def __init__(self) -> None:
+        self.cmds: list[list[str]] = []
+
+
+def test_k8s_cleanup_invoked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """在 k8s 场景下，当提供删除 YAML 时，应调用 kubectl delete。"""
+
+    # 构造 k8s 混合场景
+    s = Scenario(
+        id="k8s_x",
+        mode="k8s-hybrid",
+        served_model_name="m",
+        model="M",
+        quant="w8a8",
+        raw={
+            "k8s": {"namespace": "default", "service_name": "infer-vllm"},
+        },
+    )
+
+    # 伪造场景查找
+    monkeypatch.setattr(
+        rp,
+        "_find_scenario",
+        lambda root, sid: s,
+    )
+
+    # 避免真实探活
+    monkeypatch.setattr(
+        rp,
+        "_discover_and_wait",
+        lambda base, sc, timeout_s=60.0: "http://127.0.0.1:9000/v1",
+    )
+    # 跳过 matrix 计划解析（直接返回空计划）
+    monkeypatch.setattr(rp, "resolve_plan", lambda m, sid, rt: {})
+    monkeypatch.setattr(
+        rp,
+        "run_smoke_suite",
+        lambda base_url, model: {"choices": [{"message": {"content": "ok"}}]},
+    )
+
+    # 写入临时 YAML 并通过环境变量声明清理
+    yml = tmp_path / "del.yaml"
+    yml.write_text("apiVersion: v1\nkind: List\nitems: []\n", encoding="utf-8")
+    monkeypatch.setenv("VLLM_CIBENCH_K8S_DELETE_YAML", str(yml))
+
+    # 捕获 subprocess.run 调用
+    calls = _Calls()
+
+    def fake_run(cmd: list[str], check: bool = False, **_: Any):  # type: ignore[override]
+        calls.cmds.append(list(map(str, cmd)))
+
+        class _R:
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    # 执行一次编排（dry-run 跳过推送）
+    res = rp.execute(
+        scenario_id="k8s_x",
+        run_type="pr",
+        root=str(Path.cwd()),
+        timeout_s=0.1,
+        dry_run=True,
+    )
+    assert res.get("functional") in {"ok", "failed", "skipped"}
+    # 断言触发了 kubectl delete 调用
+    assert any(cmd[:2] == ["kubectl", "delete"] for cmd in calls.cmds)


### PR DESCRIPTION
- Add optional K8s cleanup after pipeline via YAML (scenario raw.k8s_delete_yaml or env VLLM_CIBENCH_K8S_DELETE_YAML).\n- Ignore cleanup errors; do not block main flow.\n- Add unit test: tests/deploy/test_k8s_cleanup.py\n- Update README: K8s cleanup instructions.\n\nValidation:\n- Rebased on latest main\n- pytest -m 'not slow' / ruff / black / isort / mypy passed locally.\n\nPlease review.\n