### PR TITLE
feat(metrics/grafana): accuracy metrics push + per-case dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ export VLLM_CIBENCH_ACCURACY_CONFIG=$(pwd)/my_accuracy.yaml
 python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run
 ```
 
+### Grafana 面板（accuracy + functional per-case）
+
+- 导入 `configs/grafana/ci_bench_dashboard.json` 到 Grafana（数据源：Prometheus）。
+- 面板说明：
+  - Accuracy Score：展示 `ci_accuracy_score` 随时间的变化（按 `model/quant/scenario` 分面）。
+  - Functional Per-Case：表格展示 `ci_functional_case_ok`（1=PASS，0=FAIL）。
+- 指标推送（Daily）：
+  - accuracy：`ci_accuracy_score`、`ci_accuracy_correct`、`ci_accuracy_total`、`ci_accuracy_ok`（labels：model/quant/scenario/task）。
+  - functional per-case：`ci_functional_case_ok`（labels：model/quant/scenario/case/kind）。
+
 ## 脚本
 
 - 部署到 K8s：

--- a/configs/grafana/ci_bench_dashboard.json
+++ b/configs/grafana/ci_bench_dashboard.json
@@ -1,0 +1,57 @@
+{
+  "__inputs": [],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0"},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "2.0.0"}
+  ],
+  "title": "vLLM CI Bench",
+  "editable": true,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Accuracy Score",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 0},
+      "targets": [
+        {
+          "expr": "ci_accuracy_score{model=\"$model\",quant=\"$quant\",scenario=\"$scenario\"}",
+          "legendFormat": "{{task}}"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Functional Per-Case",
+      "gridPos": {"h": 12, "w": 24, "x": 0, "y": 8},
+      "transformations": [],
+      "options": {"showHeader": true},
+      "targets": [
+        {
+          "expr": "ci_functional_case_ok{model=\"$model\",quant=\"$quant\",scenario=\"$scenario\"}",
+          "format": "table",
+          "legendFormat": "{{kind}} {{case}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {"type": "value", "options": {"0": {"text": "FAIL", "color": "red"}, "1": {"text": "PASS", "color": "green"}}}
+          ],
+          "thresholds": {"mode": "absolute", "steps": [{"value": null, "color": "red"}, {"value": 1, "color": "green"}]}
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {"type": "datasource", "name": "DS_PROM", "query": "prometheus"},
+      {"type": "query", "name": "model", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, model)", "includeAll": false},
+      {"type": "query", "name": "quant", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, quant)", "includeAll": false},
+      {"type": "query", "name": "scenario", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, scenario)", "includeAll": false}
+    ]
+  },
+  "time": {"from": "now-7d", "to": "now"},
+  "timezone": "",
+  "version": 1
+}
+

--- a/tests/metrics/test_accuracy_push.py
+++ b/tests/metrics/test_accuracy_push.py
@@ -1,0 +1,54 @@
+"""Accuracy 指标推送（daily-only）测试。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Mapping, Tuple
+
+import pytest
+
+import vllm_cibench.orchestrators.run_pipeline as rp
+
+
+@pytest.mark.accuracy
+def test_push_accuracy_metrics_daily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """在 daily 且非 dry-run 下，应推送 accuracy 指标到 Pushgateway。"""
+
+    # 避免真实探活
+    monkeypatch.setattr(
+        rp, "_discover_and_wait", lambda *a, **k: "http://127.0.0.1:9000/v1"
+    )
+    monkeypatch.setattr(
+        rp,
+        "run_smoke_suite",
+        lambda *a, **k: {"choices": [{"message": {"content": "ok"}}]},
+    )
+
+    # 固定 accuracy 结果
+    monkeypatch.setattr(
+        rp,
+        "run_accuracy",
+        lambda **kwargs: {"task": "gpqa", "score": 0.8, "correct": 8, "total": 10},
+    )
+
+    # 捕获 push_metrics 调用
+    calls: List[Tuple[str, Mapping[str, float], Mapping[str, str]]] = []
+
+    def fake_push(job: str, metrics: Mapping[str, float], *, labels: Mapping[str, str], run_type: str, dry_run: bool) -> bool:  # type: ignore[override]
+        calls.append((job, metrics, labels))
+        return True
+
+    monkeypatch.setattr(rp, "push_metrics", fake_push)
+
+    _ = rp.execute(
+        scenario_id="local_single_qwen3-32b_guided_w8a8",
+        run_type="daily",
+        root=str(Path.cwd()),
+        timeout_s=0.1,
+        dry_run=False,
+    )
+
+    # 断言存在 accuracy 指标推送
+    assert any("ci_accuracy_score" in m for _, m, _ in calls)


### PR DESCRIPTION
- Push accuracy metrics on daily: ci_accuracy_score/correct/total/ok with labels (model, quant, scenario, task).\n- Add Grafana dashboard: configs/grafana/ci_bench_dashboard.json (accuracy timeseries + functional per-case table).\n- Tests: tests/metrics/test_accuracy_push.py.\n\nValidation: ruff/black/isort/mypy/pytest passed locally.\n\nPlease review.