### PR TITLE
docs(grafana): add perf panels + variables (metric_prefix, quantile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,15 +116,19 @@ export VLLM_CIBENCH_ACCURACY_CONFIG=$(pwd)/my_accuracy.yaml
 python -m vllm_cibench.run run --scenario local_single_qwen3-32b_guided_w8a8 --run-type pr --dry-run
 ```
 
-### Grafana 面板（accuracy + functional per-case）
+### Grafana 面板（accuracy + perf + functional per-case）
 
 - 导入 `configs/grafana/ci_bench_dashboard.json` 到 Grafana（数据源：Prometheus）。
 - 面板说明：
   - Accuracy Score：展示 `ci_accuracy_score` 随时间的变化（按 `model/quant/scenario` 分面）。
+  - Perf Throughput/Latency：展示 `ci_perf_throughput_rps_avg` 与 `ci_perf_latency_${quantile}_ms_avg`；默认 quantile=p50。
+  - Functional Pass Rate：展示 `ci_functional_pass_rate`。
   - Functional Per-Case：表格展示 `ci_functional_case_ok`（1=PASS，0=FAIL）。
 - 指标推送（Daily）：
   - accuracy：`ci_accuracy_score`、`ci_accuracy_correct`、`ci_accuracy_total`、`ci_accuracy_ok`（labels：model/quant/scenario/task）。
+  - functional：`ci_functional_pass_rate`、`ci_functional_total`、`ci_functional_passed`、`ci_functional_failed`。
   - functional per-case：`ci_functional_case_ok`（labels：model/quant/scenario/case/kind）。
+  - perf：`ci_perf_throughput_rps_avg`、`ci_perf_latency_p50_ms_avg`。
 
 ## 脚本
 

--- a/configs/grafana/ci_bench_dashboard.json
+++ b/configs/grafana/ci_bench_dashboard.json
@@ -40,6 +40,39 @@
         },
         "overrides": []
       }
+    },
+    {
+      "type": "timeseries",
+      "title": "Perf Throughput (RPS)",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "targets": [
+        {
+          "expr": "${metric_prefix}perf_throughput_rps_avg{model=\"$model\",quant=\"$quant\",scenario=\"$scenario\"}",
+          "legendFormat": "throughput_rps_avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Perf Latency (${quantile})",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "targets": [
+        {
+          "expr": "${metric_prefix}perf_latency_${quantile}_ms_avg{model=\"$model\",quant=\"$quant\",scenario=\"$scenario\"}",
+          "legendFormat": "latency_${quantile}_ms_avg"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Functional Pass Rate",
+      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 28},
+      "targets": [
+        {
+          "expr": "${metric_prefix}functional_pass_rate{model=\"$model\",quant=\"$quant\",scenario=\"$scenario\"}",
+          "legendFormat": "pass_rate"
+        }
+      ]
     }
   ],
   "templating": {
@@ -47,11 +80,12 @@
       {"type": "datasource", "name": "DS_PROM", "query": "prometheus"},
       {"type": "query", "name": "model", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, model)", "includeAll": false},
       {"type": "query", "name": "quant", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, quant)", "includeAll": false},
-      {"type": "query", "name": "scenario", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, scenario)", "includeAll": false}
+      {"type": "query", "name": "scenario", "datasource": "$DS_PROM", "query": "label_values(ci_accuracy_score, scenario)", "includeAll": false},
+      {"type": "textbox", "name": "metric_prefix", "query": "ci_", "label": "Metric Prefix"},
+      {"type": "custom", "name": "quantile", "query": "p50", "label": "Latency Quantile"}
     ]
   },
   "time": {"from": "now-7d", "to": "now"},
   "timezone": "",
   "version": 1
 }
-


### PR DESCRIPTION
- Dashboard: add perf throughput/latency panels; variables metric_prefix (default ci_) and quantile (default p50).\n- README updated to describe panels and pushed metrics.\n\nNo code changes; tests unchanged (docs only).