### PR TITLE
feat(perf/metrics): add p95/p99 latency aggregation

### DIFF
--- a/src/vllm_cibench/metrics/pushgateway.py
+++ b/src/vllm_cibench/metrics/pushgateway.py
@@ -59,16 +59,25 @@ def metrics_from_perf_records(
 
     thr = []
     p50 = []
+    p95 = []
+    p99 = []
     for r in records:
         if "throughput_rps" in r:
             thr.append(float(r["throughput_rps"]))
         if "latency_p50_ms" in r:
             p50.append(float(r["latency_p50_ms"]))
+        if "latency_p95_ms" in r:
+            p95.append(float(r["latency_p95_ms"]))
+        if "latency_p99_ms" in r:
+            p99.append(float(r["latency_p99_ms"]))
     out: Dict[str, float] = {}
     if thr:
         out["ci_perf_throughput_rps_avg"] = sum(thr) / len(thr)
     if p50:
         out["ci_perf_latency_p50_ms_avg"] = sum(p50) / len(p50)
+    # 若不存在相应分位数记录，则给出占位 -1，便于面板与告警配置
+    out.setdefault("ci_perf_latency_p95_ms_avg", (sum(p95) / len(p95)) if p95 else -1.0)
+    out.setdefault("ci_perf_latency_p99_ms_avg", (sum(p99) / len(p99)) if p99 else -1.0)
     return out
 
 

--- a/tests/metrics/test_pushgateway.py
+++ b/tests/metrics/test_pushgateway.py
@@ -96,3 +96,29 @@ def test_metrics_from_perf_records():
     )
     assert out["ci_perf_throughput_rps_avg"] == 15
     assert out["ci_perf_latency_p50_ms_avg"] == 50
+    # 未提供 p95/p99 时使用占位 -1
+    assert out["ci_perf_latency_p95_ms_avg"] == -1.0
+    assert out["ci_perf_latency_p99_ms_avg"] == -1.0
+
+
+def test_metrics_from_perf_records_with_quantiles():
+    out = pg.metrics_from_perf_records(
+        [
+            {
+                "throughput_rps": 10,
+                "latency_p50_ms": 40,
+                "latency_p95_ms": 80,
+                "latency_p99_ms": 100,
+            },
+            {
+                "throughput_rps": 20,
+                "latency_p50_ms": 60,
+                "latency_p95_ms": 120,
+                "latency_p99_ms": 140,
+            },
+        ]
+    )
+    assert out["ci_perf_throughput_rps_avg"] == 15
+    assert out["ci_perf_latency_p50_ms_avg"] == 50
+    assert out["ci_perf_latency_p95_ms_avg"] == 100
+    assert out["ci_perf_latency_p99_ms_avg"] == 120


### PR DESCRIPTION
- Add ci_perf_latency_p95_ms_avg and ci_perf_latency_p99_ms_avg aggregation in metrics_from_perf_records.\n- Use -1 placeholders when not present in records (to support dashboards/alerts).\n- Tests updated to cover default and present quantiles.\n\nNo changes required in pipeline push; existing flow pushes aggregated metrics.\n