### PR TITLE
feat(perf/parse): support p95/p99 columns in CSV parsing

### DIFF
--- a/src/vllm_cibench/testsuites/perf.py
+++ b/src/vllm_cibench/testsuites/perf.py
@@ -83,13 +83,23 @@ def parse_perf_csv(csv_text: str) -> List[Dict[str, Any]]:
     out: List[Dict[str, Any]] = []
     reader = csv.DictReader(io.StringIO(csv_text))
     for row in reader:
-        out.append(
-            {
-                "concurrency": int(row["concurrency"]),
-                "input_len": int(row["input_len"]),
-                "output_len": int(row["output_len"]),
-                "latency_p50_ms": float(row["latency_p50_ms"]),
-                "throughput_rps": float(row["throughput_rps"]),
-            }
-        )
+        item: Dict[str, Any] = {
+            "concurrency": int(row["concurrency"]),
+            "input_len": int(row["input_len"]),
+            "output_len": int(row["output_len"]),
+            "latency_p50_ms": float(row["latency_p50_ms"]),
+            "throughput_rps": float(row["throughput_rps"]),
+        }
+        # 可选分位：latency_p95_ms / latency_p99_ms
+        if "latency_p95_ms" in row and row["latency_p95_ms"] not in (None, ""):
+            try:
+                item["latency_p95_ms"] = float(row["latency_p95_ms"])
+            except Exception:
+                pass
+        if "latency_p99_ms" in row and row["latency_p99_ms"] not in (None, ""):
+            try:
+                item["latency_p99_ms"] = float(row["latency_p99_ms"])
+            except Exception:
+                pass
+        out.append(item)
     return out

--- a/tests/testsuites/test_perf_quantiles_parse.py
+++ b/tests/testsuites/test_perf_quantiles_parse.py
@@ -1,0 +1,26 @@
+"""性能 CSV 解析：可选 p95/p99 字段测试。"""
+
+from __future__ import annotations
+
+from vllm_cibench.testsuites.perf import parse_perf_csv
+
+
+def test_parse_perf_with_quantiles():
+    csv = (
+        "concurrency,input_len,output_len,latency_p50_ms,latency_p95_ms,latency_p99_ms,throughput_rps\n"
+        "1,128,128,40,80,100,10\n"
+        "2,128,128,60,120,140,20\n"
+    )
+    out = parse_perf_csv(csv)
+    assert out[0]["latency_p95_ms"] == 80.0 and out[0]["latency_p99_ms"] == 100.0
+    assert out[1]["latency_p95_ms"] == 120.0 and out[1]["latency_p99_ms"] == 140.0
+
+
+def test_parse_perf_without_quantiles():
+    csv = (
+        "concurrency,input_len,output_len,latency_p50_ms,throughput_rps\n"
+        "1,128,128,40,10\n"
+        "2,128,128,60,20\n"
+    )
+    out = parse_perf_csv(csv)
+    assert "latency_p95_ms" not in out[0] and "latency_p99_ms" not in out[0]


### PR DESCRIPTION
- parse_perf_csv now parses optional latency_p95_ms and latency_p99_ms columns.\n- Tests added to cover with/without quantiles.\n- Complements metrics aggregation for p95/p99 (PR #81).